### PR TITLE
Buddy allocator

### DIFF
--- a/src/buddy.rs
+++ b/src/buddy.rs
@@ -70,7 +70,7 @@ impl BuddyEntry {
     }
 }
 
-struct BuddyAllocator<const CAPACITY: usize, const HIGHEST_ORDER: u8, const LOWEST_ORDER: u8>
+pub struct BuddyAllocator<const CAPACITY: usize, const HIGHEST_ORDER: u8, const LOWEST_ORDER: u8>
 where
     [(); (HIGHEST_ORDER - LOWEST_ORDER + 1) as usize]:,
 {

--- a/src/buddy.rs
+++ b/src/buddy.rs
@@ -1,0 +1,123 @@
+#[derive(Clone, Copy)]
+struct LeafBuddyEntry {
+    size: u32,
+    free: bool,
+    sibling: u32,
+    parent: u32,
+    next_of_this_size: u32,
+    previous_of_this_size: u32,
+}
+#[derive(Clone, Copy)]
+struct ParentBuddyEntry {
+    size: u32,
+    left_child: u32,
+    right_child: u32,
+    parent: u32,
+}
+#[derive(Clone, Copy)]
+struct UnusedBuddyEntry {
+    next: u32,
+    previous: u32,
+}
+
+#[derive(Clone, Copy)]
+enum BuddyEntry {
+    Unused(UnusedBuddyEntry),
+    Parent(ParentBuddyEntry),
+    Leaf(LeafBuddyEntry),
+}
+
+impl BuddyEntry {
+    fn as_leaf(&self) -> &LeafBuddyEntry {
+        match self {
+            BuddyEntry::Leaf(leaf) => leaf,
+            _ => panic!("Not a leaf but expected to be"),
+        }
+    }
+    fn as_leaf_mut(&mut self) -> &mut LeafBuddyEntry {
+        match self {
+            BuddyEntry::Leaf(leaf) => leaf,
+            _ => panic!("Not a leaf but expected to be"),
+        }
+    }
+
+    fn as_parent(&self) -> &ParentBuddyEntry {
+        match self {
+            BuddyEntry::Parent(parent) => parent,
+            _ => panic!("Not a parent but expected to be"),
+        }
+    }
+    fn as_parent_mut(&mut self) -> &mut ParentBuddyEntry {
+        match self {
+            BuddyEntry::Parent(parent) => parent,
+            _ => panic!("Not a parent but expected to be"),
+        }
+    }
+
+    fn as_unused(&self) -> &UnusedBuddyEntry {
+        match self {
+            BuddyEntry::Unused(unused) => unused,
+            _ => panic!("Not an unused entry but expected to be"),
+        }
+    }
+    fn as_unused_mut(&mut self) -> &mut UnusedBuddyEntry {
+        match self {
+            BuddyEntry::Unused(unused) => unused,
+            _ => panic!("Not an unused entry but expected to be"),
+        }
+    }
+}
+
+struct BuddyAllocator<const CAPACITY: u32, const HIGHEST_ORDER: usize, const LOWEST_ORDER: usize>
+where
+    [(); HIGHEST_ORDER - LOWEST_ORDER + 1]:,
+    [(); CAPACITY as usize]:,
+{
+    entries: [BuddyEntry; CAPACITY as usize],
+    first_free_indices_for_orders: [Option<u32>; HIGHEST_ORDER - LOWEST_ORDER + 1],
+    unused_entries: Option<u32>,
+}
+
+impl<const CAPACITY: u32, const HIGHEST_ORDER: usize, const LOWEST_ORDER: usize>
+    BuddyAllocator<CAPACITY, HIGHEST_ORDER, LOWEST_ORDER>
+where
+    [(); HIGHEST_ORDER - LOWEST_ORDER + 1]:,
+    [(); CAPACITY as usize]:,
+{
+    const NON_EXISTANT_INDEX: u32 = u32::MAX;
+
+    /// Creates a buddy allocator which has all elements initialized to zero (probably) and all indices None.
+    /// This is a good state in which to call .all_unused(), which initializes the unused indices properly.
+    /// The reason why this not the default is that initializing with zeros allows for storage in the BSS section (good for large buddy allocators).
+    /// Additionally, using assignment would mean (potentially) having to store one of these things on the stack, which may be impossible for large ones. Using a builder-style interface is the best I can think of.
+    pub const fn unusable() -> Self {
+        Self {
+            entries: [BuddyEntry::Unused(UnusedBuddyEntry {
+                next: 0,
+                previous: 0,
+            }); CAPACITY as usize],
+            first_free_indices_for_orders: [None; HIGHEST_ORDER - LOWEST_ORDER + 1],
+            unused_entries: None,
+        }
+    }
+
+    pub fn all_unused(&mut self) -> &mut Self {
+        self.unused_entries = Some(0);
+        // Initialize the middle entries separately for simplicity.
+        self.entries[0] = BuddyEntry::Unused(UnusedBuddyEntry {
+            next: 1,
+            previous: Self::NON_EXISTANT_INDEX,
+        });
+        for i in 1..CAPACITY - 1 {
+            self.entries[i as usize] = BuddyEntry::Unused(UnusedBuddyEntry {
+                next: (i + 1) as u32,
+                previous: (i - 1) as u32,
+            });
+        }
+        self.entries[(CAPACITY - 1) as usize] = BuddyEntry::Unused(UnusedBuddyEntry {
+            next: Self::NON_EXISTANT_INDEX,
+            previous: (CAPACITY - 2) as u32,
+        });
+        self
+    }
+}

--- a/src/buddy.rs
+++ b/src/buddy.rs
@@ -1,7 +1,6 @@
 #[derive(Clone, Copy)]
 struct LeafBuddyEntry {
     order: u8,
-    free: bool,
     address: usize,
     sibling: u32,
     parent: u32,
@@ -185,7 +184,6 @@ where
         let order = Self::get_order(size);
         *first_unused_entry = BuddyEntry::Leaf(LeafBuddyEntry {
             order,
-            free: true,
             address,
             sibling: Self::NON_EXISTANT_INDEX,
             parent: Self::NON_EXISTANT_INDEX,
@@ -203,7 +201,6 @@ where
         let old_entry = self.entries[index as usize].as_leaf_mut();
         let left_child = LeafBuddyEntry {
             order: old_entry.order - 1,
-            free: true,
             address: old_entry.address,
             sibling: right_child_index,
             parent: index,
@@ -212,7 +209,6 @@ where
         };
         let right_child = LeafBuddyEntry {
             order: old_entry.order - 1,
-            free: true,
             address: old_entry.address + Self::get_size(old_entry.order - 1),
             sibling: left_child_index,
             parent: index,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
 )]
 
 mod assert;
+mod buddy;
 mod lazy_init;
 mod memory;
 mod paging;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@
     const_maybe_uninit_uninit_array,
     const_mut_refs,
     const_maybe_uninit_write,
-    const_maybe_uninit_array_assume_init
+    const_maybe_uninit_array_assume_init,
+    let_chains,
 )]
 // While I don't enjoy surpressing warnings, I think that this particular warning is unnecessary at this stage of development. It would be more useful when the basic components are in place and working.
 #![allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@
     const_maybe_uninit_write,
     const_maybe_uninit_array_assume_init
 )]
+// While I don't enjoy surpressing warnings, I think that this particular warning is unnecessary at this stage of development. It would be more useful when the basic components are in place and working.
+#![allow(dead_code)]
 
 mod assert;
 mod buddy;


### PR DESCRIPTION
This creates a generic buddy allocator structure and associated implementation which is able to perform fine-grain allocations using the standard buddy algorithm (or something like it).

I also use the buddy allocator to manage the page table allocator (the one with urgent TODOs all over it), which allows us to remove the TODOs.