### PR TITLE
Allow lazy static buddy allocator in bss

### DIFF
--- a/src/buddy.rs
+++ b/src/buddy.rs
@@ -23,7 +23,9 @@ struct UnusedBuddyEntry {
 }
 
 #[derive(Clone, Copy)]
+#[repr(u32)]
 enum BuddyEntry {
+    Uninitialized = 0,
     Unused(UnusedBuddyEntry),
     Parent(ParentBuddyEntry),
     Leaf(LeafBuddyEntry),
@@ -93,10 +95,7 @@ where
     /// Additionally, using assignment would mean (potentially) having to store one of these things on the stack, which may be impossible for large ones. Using a builder-style interface is the best I can think of.
     pub const fn unusable() -> Self {
         Self {
-            entries: [BuddyEntry::Unused(UnusedBuddyEntry {
-                next: 0,
-                previous: 0,
-            }); CAPACITY],
+            entries: [BuddyEntry::Uninitialized; CAPACITY],
             free_indices_for_orders: [None; (HIGHEST_ORDER - LOWEST_ORDER + 1) as usize],
             allocated_indices_for_orders: [None; (HIGHEST_ORDER - LOWEST_ORDER + 1) as usize],
             unused_entries: None,

--- a/src/buddy.rs
+++ b/src/buddy.rs
@@ -110,12 +110,12 @@ where
             previous: Self::NON_EXISTANT_INDEX,
         });
         for i in 1..CAPACITY - 1 {
-            self.entries[i as usize] = BuddyEntry::Unused(UnusedBuddyEntry {
+            self.entries[i] = BuddyEntry::Unused(UnusedBuddyEntry {
                 next: (i + 1) as u32,
                 previous: (i - 1) as u32,
             });
         }
-        self.entries[(CAPACITY - 1) as usize] = BuddyEntry::Unused(UnusedBuddyEntry {
+        self.entries[CAPACITY - 1] = BuddyEntry::Unused(UnusedBuddyEntry {
             next: Self::NON_EXISTANT_INDEX,
             previous: (CAPACITY - 2) as u32,
         });
@@ -396,12 +396,10 @@ where
                 self.entries[index as usize].as_leaf_mut().free = true;
                 self.merge(index);
                 return;
+            } else if entry.next_of_this_size != Self::NON_EXISTANT_INDEX {
+                optional_index = Some(entry.next_of_this_size);
             } else {
-                if entry.next_of_this_size != Self::NON_EXISTANT_INDEX {
-                    optional_index = Some(entry.next_of_this_size);
-                } else {
-                    optional_index = None;
-                }
+                optional_index = None;
             }
         }
         panic!("Attempt to free address which was either not allocated (as this size) or already freed: {}", address);

--- a/src/lazy_init.rs
+++ b/src/lazy_init.rs
@@ -1,49 +1,56 @@
-macro_rules! lazy_static {
-    ($visibility:vis static ref $name:ident : $type:ty = $initializer:expr ;) => {
-        #[allow(non_camel_case_types)]
-        $visibility struct $name {
-    value: core::cell::UnsafeCell<Option<$type>>,
+use core::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+};
+
+pub struct LazilyInitialized<'initializer, T: Sized + Sync> {
+    value: UnsafeCell<Option<T>>,
+    initializer: &'initializer dyn Fn() -> T,
 }
 
-impl $name {
-    const fn new() -> Self {
+impl<'initializer, T: Sized + Sync> LazilyInitialized<'initializer, T> {
+    pub const fn new(initializer: &'initializer dyn Fn() -> T) -> Self {
         Self {
-            value: core::cell::UnsafeCell::new(None),
+            value: UnsafeCell::new(None),
+            initializer,
         }
     }
 
-    $visibility fn is_initialized(value: &Self) -> bool {
+    pub fn is_initialized(value: &Self) -> bool {
         // TODO: Make this safe. It should be ok for now because we don't have threads yet. Same goes for the rest of these functions.
         unsafe { value.value.get().as_ref().unwrap().is_some() }
     }
 }
 
-impl core::ops::Deref for $name {
-    type Target = $type;
+impl<'initializer, T: Sized + Sync> Deref for LazilyInitialized<'initializer, T> {
+    type Target = T;
 
-    // Needed if the initializer uses an unsafe block (this also hides other warnings but such is life).
-    #[allow(unused_unsafe)]
-    fn deref(&self) -> &$type {
+    fn deref(&self) -> &T {
         // TODO: Make safe (see above)
         unsafe {
             if self.value.get().as_ref().is_none() {
-                *self.value.get() = Some($initializer);
+                *self.value.get() = Some((self.initializer)());
             }
             self.value.get().as_ref().unwrap().as_ref().unwrap()
         }
     }
 }
 
-impl core::ops::DerefMut for $name {
-    fn deref_mut(&mut self) -> &mut $type {
+impl<'initializer, T: Sized + Sync> DerefMut for LazilyInitialized<'initializer, T> {
+    fn deref_mut(&mut self) -> &mut T {
         // TODO: Make safe.
+        unsafe {
             if self.value.get_mut().is_none() {
-                *self.value.get_mut() = Some($initializer);
+                *self.value.get() = Some((self.initializer)());
             }
             self.value.get_mut().as_mut().unwrap()
+        }
     }
 }
-        $visibility static mut $name: $name = $name::new();
+
+macro_rules! lazy_static {
+    ($visibility:vis static ref $name:ident : $type:ty = $initializer:expr ;) => {
+        $visibility static mut $name: crate::lazy_init::LazilyInitialized<$type> = crate::lazy_init::LazilyInitialized::new(&||$initializer);
     };
 }
 
@@ -51,7 +58,7 @@ pub(crate) use lazy_static;
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::lazy_init::LazilyInitialized;
 
     struct CantConstructAtCompileTime {
         nums: [u8; 24],
@@ -70,9 +77,9 @@ mod test {
     #[test]
     fn lazy_initialization_test() {
         unsafe {
-            assert!(!LAZY_VARIABLE::is_initialized(&LAZY_VARIABLE));
+            assert!(!LazilyInitialized::is_initialized(&LAZY_VARIABLE));
             LAZY_VARIABLE.nums[0] = 56;
-            assert!(LAZY_VARIABLE::is_initialized(&LAZY_VARIABLE));
+            assert!(LazilyInitialized::is_initialized(&LAZY_VARIABLE));
             assert_eq!(LAZY_VARIABLE.nums[0], 56);
             assert_eq!(LAZY_VARIABLE.nums[1], 42);
         }

--- a/src/lazy_init.rs
+++ b/src/lazy_init.rs
@@ -1,56 +1,49 @@
-use core::{
-    cell::UnsafeCell,
-    ops::{Deref, DerefMut},
-};
-
-pub struct LazilyInitialized<'initializer, T: Sized + Sync> {
-    value: UnsafeCell<Option<T>>,
-    initializer: &'initializer dyn Fn() -> T,
+macro_rules! lazy_static {
+    ($visibility:vis static ref $name:ident : $type:ty = $initializer:expr ;) => {
+        #[allow(non_camel_case_types)]
+        $visibility struct $name {
+    value: core::cell::UnsafeCell<Option<$type>>,
 }
 
-impl<'initializer, T: Sized + Sync> LazilyInitialized<'initializer, T> {
-    pub const fn new(initializer: &'initializer dyn Fn() -> T) -> Self {
+impl $name {
+    const fn new() -> Self {
         Self {
-            value: UnsafeCell::new(None),
-            initializer,
+            value: core::cell::UnsafeCell::new(None),
         }
     }
 
-    pub fn is_initialized(value: &Self) -> bool {
+    $visibility fn is_initialized(value: &Self) -> bool {
         // TODO: Make this safe. It should be ok for now because we don't have threads yet. Same goes for the rest of these functions.
         unsafe { value.value.get().as_ref().unwrap().is_some() }
     }
 }
 
-impl<'initializer, T: Sized + Sync> Deref for LazilyInitialized<'initializer, T> {
-    type Target = T;
+impl core::ops::Deref for $name {
+    type Target = $type;
 
-    fn deref(&self) -> &T {
+    // Needed if the initializer uses an unsafe block (this also hides other warnings but such is life).
+    #[allow(unused_unsafe)]
+    fn deref(&self) -> &$type {
         // TODO: Make safe (see above)
         unsafe {
             if self.value.get().as_ref().is_none() {
-                *self.value.get() = Some((self.initializer)());
+                *self.value.get() = Some($initializer);
             }
             self.value.get().as_ref().unwrap().as_ref().unwrap()
         }
     }
 }
 
-impl<'initializer, T: Sized + Sync> DerefMut for LazilyInitialized<'initializer, T> {
-    fn deref_mut(&mut self) -> &mut T {
+impl core::ops::DerefMut for $name {
+    fn deref_mut(&mut self) -> &mut $type {
         // TODO: Make safe.
-        unsafe {
             if self.value.get_mut().is_none() {
-                *self.value.get() = Some((self.initializer)());
+                *self.value.get_mut() = Some($initializer);
             }
             self.value.get_mut().as_mut().unwrap()
-        }
     }
 }
-
-macro_rules! lazy_static {
-    ($visibility:vis static ref $name:ident : $type:ty = $initializer:expr ;) => {
-        $visibility static mut $name: crate::lazy_init::LazilyInitialized<$type> = crate::lazy_init::LazilyInitialized::new(&||$initializer);
+        $visibility static mut $name: $name = $name::new();
     };
 }
 
@@ -58,7 +51,7 @@ pub(crate) use lazy_static;
 
 #[cfg(test)]
 mod test {
-    use crate::lazy_init::LazilyInitialized;
+    use super::*;
 
     struct CantConstructAtCompileTime {
         nums: [u8; 24],
@@ -77,9 +70,9 @@ mod test {
     #[test]
     fn lazy_initialization_test() {
         unsafe {
-            assert!(!LazilyInitialized::is_initialized(&LAZY_VARIABLE));
+            assert!(!LAZY_VARIABLE::is_initialized(&LAZY_VARIABLE));
             LAZY_VARIABLE.nums[0] = 56;
-            assert!(LazilyInitialized::is_initialized(&LAZY_VARIABLE));
+            assert!(LAZY_VARIABLE::is_initialized(&LAZY_VARIABLE));
             assert_eq!(LAZY_VARIABLE.nums[0], 56);
             assert_eq!(LAZY_VARIABLE.nums[1], 42);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@
     const_maybe_uninit_array_assume_init,
     let_chains,
 )]
+// Shut up the compiler about const generic expressions.
+#![allow(incomplete_features)]
 // While I don't enjoy surpressing warnings, I think that this particular warning is unnecessary at this stage of development. It would be more useful when the basic components are in place and working.
 #![allow(dead_code)]
 


### PR DESCRIPTION
Dispite the branch name, this PR actually doesn't make any changes to the lazy static macro itself. The actual change was in the buddy allocator, where I added a new enum constant for uninitialized data. This works better since it forces the compiler to set that memory to zero and thus allows the buddy allocators to reside in BSS.


This tecnique should be used in future lazily initialized structures (have an option to have uninitialized data) and store a static variable in the initializer and hand out a reference to it as the type of the public static variable. Most of the other alternatives are less clean and/or rely on putting large objects on the stack, which is a recipe for disaster.