### PR TITLE
Virtual memory allocator + first stage of heap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.log
 
 .vscode/
+
+.config

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -6,8 +6,8 @@ use crate::{
     assert::const_assert,
     buddy::BuddyAllocator,
     lazy_init::lazy_static,
-    paging::{map_block, unmap_block},
-    pmm::{BLOCK_SIZE, LOG2_BLOCK_SIZE},
+    paging::{get_physical_address, map_block, unmap_block},
+    pmm::{mark_as_free, BLOCK_SIZE, LOG2_BLOCK_SIZE},
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -71,6 +71,7 @@ unsafe impl GlobalAlloc for HeapAllocator {
         // Same logic as above.
         if size >= BLOCK_SIZE {
             for block_address in (address..(address + size)).step_by(BLOCK_SIZE) {
+                mark_as_free(get_physical_address(block_address));
                 unmap_block(block_address);
             }
             HEAP_VIRTUAL_MEMORY_ALLOCATOR.free(size, address);

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,5 +1,11 @@
+use core::{alloc::GlobalAlloc, ptr::null_mut};
+
 use crate::{
-    assert::const_assert, buddy::BuddyAllocator, lazy_init::lazy_static, pmm::LOG2_BLOCK_SIZE,
+    assert::const_assert,
+    buddy::BuddyAllocator,
+    lazy_init::lazy_static,
+    paging::{map_block, unmap_block},
+    pmm::{BLOCK_SIZE, LOG2_BLOCK_SIZE},
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -20,8 +26,54 @@ lazy_static! {
         static mut REAL_ALLOCATOR: BuddyAllocator<256, LOG2_HEAP_SIZE, LOG2_BLOCK_SIZE> =
             BuddyAllocator::unusable();
         unsafe {
-            REAL_ALLOCATOR.add_entry(HEAP_SIZE, VIRTUAL_HEAP_START);
+            REAL_ALLOCATOR
+                .all_unused()
+                .add_entry(HEAP_SIZE, VIRTUAL_HEAP_START);
             &mut REAL_ALLOCATOR
         }
     };
+}
+
+struct HeapAllocator;
+
+unsafe impl GlobalAlloc for HeapAllocator {
+    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+        // If the allocation is for less than the size of a block, we use a different algorithm.
+        // Otherwise we simply allocate the required amount of virtual memory and map it to freshly allocated physical memory.
+        let size = layout.size().next_power_of_two();
+        // Buddy allocators align memory to its size, so we shouldn't have to worry about alignment here.
+        assert!(layout.align() <= size);
+        if size >= BLOCK_SIZE {
+            let address = HEAP_VIRTUAL_MEMORY_ALLOCATOR.allocate(size);
+            if let Some(address) = address {
+                for virtual_block_address in (address..(address + size)).step_by(BLOCK_SIZE) {
+                    let physical_block_address = crate::pmm::allocate_block_address();
+                    if let Some(physical_address) = physical_block_address {
+                        map_block(virtual_block_address, physical_address);
+                    } else {
+                        return null_mut();
+                    }
+                }
+                return address as *mut u8;
+            } else {
+                return null_mut();
+            }
+        } else {
+            todo!();
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
+        let address = ptr as usize;
+        let size = layout.size().next_power_of_two();
+        // Same logic as above.
+        if size >= BLOCK_SIZE {
+            for block_address in (address..(address + size)).step_by(BLOCK_SIZE) {
+                unmap_block(block_address);
+            }
+            HEAP_VIRTUAL_MEMORY_ALLOCATOR.free(size, address);
+        } else {
+            todo!();
+        }
+    }
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -78,5 +78,6 @@ unsafe impl GlobalAlloc for HeapAllocator {
     }
 }
 
+#[cfg(not(test))]
 #[global_allocator]
 static GLOBAL_ALLOCATOR: HeapAllocator = HeapAllocator {};

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,5 +1,27 @@
+use crate::{
+    assert::const_assert, buddy::BuddyAllocator, lazy_init::lazy_static, pmm::LOG2_BLOCK_SIZE,
+};
+
 #[cfg(target_arch = "x86_64")]
 const VIRTUAL_HEAP_START: usize = 0xffffa00000000000;
 
 #[cfg(target_arch = "x86_64")]
 const HEAP_SIZE: usize = 0x1000000000; // 64GB
+
+const LOG2_HEAP_SIZE: u8 = HEAP_SIZE.trailing_zeros() as u8;
+
+const_assert!(
+    1 << LOG2_HEAP_SIZE == HEAP_SIZE,
+    "HEAP_SIZE must be a power of two"
+);
+
+lazy_static! {
+    static ref HEAP_VIRTUAL_MEMORY_ALLOCATOR: &mut BuddyAllocator<256, LOG2_HEAP_SIZE, LOG2_BLOCK_SIZE> = {
+        static mut REAL_ALLOCATOR: BuddyAllocator<256, LOG2_HEAP_SIZE, LOG2_BLOCK_SIZE> =
+            BuddyAllocator::unusable();
+        unsafe {
+            REAL_ALLOCATOR.add_entry(HEAP_SIZE, VIRTUAL_HEAP_START);
+            &mut REAL_ALLOCATOR
+        }
+    };
+}

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -54,9 +54,9 @@ unsafe impl GlobalAlloc for HeapAllocator {
                         return null_mut();
                     }
                 }
-                return address as *mut u8;
+                address as *mut u8
             } else {
-                return null_mut();
+                null_mut()
             }
         } else {
             todo!();

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -77,3 +77,6 @@ unsafe impl GlobalAlloc for HeapAllocator {
         }
     }
 }
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: HeapAllocator = HeapAllocator {};

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,0 +1,5 @@
+#[cfg(target_arch = "x86_64")]
+const VIRTUAL_HEAP_START: usize = 0xffffa00000000000;
+
+#[cfg(target_arch = "x86_64")]
+const HEAP_SIZE: usize = 0x1000000000; // 64GB

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,18 +42,11 @@ use core::panic::PanicInfo;
 
 extern crate alloc;
 
-use alloc::boxed::Box;
-
 #[panic_handler]
 #[cfg(not(test))]
 fn kpanic(_info: &PanicInfo) -> ! {
     console::write_string("Panic!!!\n");
     loop {}
-}
-
-#[inline(never)]
-fn test_allocator() -> Box<[u8; 1048576]> {
-    unsafe { Box::new_zeroed().assume_init() }
 }
 
 #[no_mangle]
@@ -62,10 +55,7 @@ extern "C" fn kmain() -> ! {
     console::write_string("Hello, World!\n");
     arch_api::init::arch_init();
     pmm::sanity_check();
-    let mut boxed_value = test_allocator();
-    for i in 0..boxed_value.len() {
-        boxed_value[i] = (i % 256) as u8;
-    }
+    heap::sanity_check();
     loop {}
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@
 
 mod assert;
 mod buddy;
+mod heap;
 mod lazy_init;
 mod memory;
 mod paging;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,4 +1,4 @@
-pub use crate::arch_api::paging::{map_page, unmap_page, PAGE_SIZE};
+pub use crate::arch_api::paging::{get_physical_address, map_page, unmap_page, PAGE_SIZE};
 use crate::pmm::PAGES_PER_BLOCK;
 
 pub fn map_block(virtual_address: usize, physical_address: usize) {

--- a/src/pmm.rs
+++ b/src/pmm.rs
@@ -123,6 +123,12 @@ where
 
 // The size of a block (bit) in the bitmap allocator.
 pub const BLOCK_SIZE: usize = 65536;
+pub const LOG2_BLOCK_SIZE: u8 = BLOCK_SIZE.trailing_zeros() as u8;
+
+const_assert!(
+    1 << LOG2_BLOCK_SIZE == BLOCK_SIZE,
+    "BLOCK_SIZE must be a power of two"
+);
 
 const_assert!(
     PAGE_SIZE < BLOCK_SIZE && BLOCK_SIZE % PAGE_SIZE == 0,

--- a/src/x86_64/arch_api/init.rs
+++ b/src/x86_64/arch_api/init.rs
@@ -2,12 +2,16 @@ use crate::{memory, pmm, x86_64::multiboot};
 
 use super::paging;
 
+#[cfg(not(test))]
 extern "C" {
     // The physical end of the kernel.
     // Note that this is not a pointer, it is actually the first thing after the kernel (in physical addressing), and therefore uses the unit type.
     #[allow(improper_ctypes)]
     static KERNEL_PHYSICAL_END: ();
 }
+
+#[cfg(test)]
+static mut KERNEL_PHYSICAL_END: () = (); // Mutable to make an unsafe block necessary.
 
 pub fn arch_init() {
     multiboot::parse_multiboot_structures();

--- a/src/x86_64/arch_api/paging.rs
+++ b/src/x86_64/arch_api/paging.rs
@@ -368,6 +368,25 @@ pub fn unmap_page(virtual_address: usize) {
     }
 }
 
+pub fn get_physical_address(virtual_address: usize) -> usize {
+    unsafe {
+        let indices = deconstruct_virtual_address(virtual_address);
+        if !is_page_table_present(&indices) {
+            panic!("Attempt to get value of unmapped page!");
+        }
+        let entry = read_page_table_entry(
+            indices.pml4_index,
+            indices.pml3_index,
+            indices.pml2_index,
+            indices.pml1_index,
+        );
+        if !entry.present {
+            panic!("Attempt to get value of unmapped page!");
+        }
+        entry.physical_address as usize + virtual_address % PAGE_SIZE
+    }
+}
+
 pub(super) fn initialize_paging() {
     // We must remove some of the mappings the startup code used (there is one which maps the first gigabyte exactly like the last, and one which maps the first 512g likewise).
     // First remove the mapping of the low 512g:

--- a/src/x86_64/arch_api/paging.rs
+++ b/src/x86_64/arch_api/paging.rs
@@ -384,10 +384,10 @@ pub(super) fn initialize_paging() {
         unmap_page(get_page_table_entry_address(RECURSIVE_PAGE_TABLE_INDEX, 511, 0, 0) as usize);
     }
     // We'll do a quick sanity check: Mapping the first 4k of physical memory to some address and then compare that with the first 4k of the last 2g (where the kernel lives).
-    map_page(0, 0);
-    let slice_in_low_memory = unsafe { core::slice::from_raw_parts(0 as *const u8, 4096) };
+    map_page(4096, 0);
+    let slice_in_low_memory = unsafe { core::slice::from_raw_parts(4096 as *const u8, 4096) };
     let slice_in_high_memory =
         unsafe { core::slice::from_raw_parts(0xffffffff80000000 as *const u8, 4096) };
     assert_eq!(slice_in_low_memory, slice_in_high_memory);
-    unmap_page(0);
+    unmap_page(4096);
 }

--- a/src/x86_64/arch_api/paging.rs
+++ b/src/x86_64/arch_api/paging.rs
@@ -122,7 +122,7 @@ fn deconstruct_virtual_address(address: usize) -> PageTableIndices {
 }
 
 lazy_static! {
-    static ref PAGE_TABLE_ALLOCATION_POOL: &'static mut BuddyAllocator<128, 16, 12> = {
+    static ref PAGE_TABLE_ALLOCATION_POOL: &'static mut BuddyAllocator<128, { pmm::LOG2_BLOCK_SIZE }, 12> = {
         static mut ACTUAL_ALLOCATOR: BuddyAllocator<128, 16, 12> = BuddyAllocator::unusable();
         unsafe { ACTUAL_ALLOCATOR.all_unused() }
     };


### PR DESCRIPTION
This adds a (very) basic heap implementation, which is only capable of allocating objects which are greater than 64k. This means a new buddy allocator for virtual memory and an implementation of the GlobalAlloc trait.

We also import the alloc crate (which gives us things like Vec and format! and so forth).

The next step is to design another allocator on top of the current heap system which is able to manage small allocations (< 64k). This might be implemented with some sort of slab-style allocator (not quite sure though).