### PR TITLE
Find acpi tables

### DIFF
--- a/aarch64-config.sh
+++ b/aarch64-config.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 sed 's/x86_64/aarch64/g' -i .config
+sed 's/"rust-analyzer.cargo.target": "x86_64-unknown-linux-gnu"/"rust-analyzer.cargo.target": "aarch64-unknown-linux-gnu"/g' -i kernel.code-workspace

--- a/common/src/beryllium.rs
+++ b/common/src/beryllium.rs
@@ -6,6 +6,7 @@ pub enum BootRequestTagType {
     StackPointer = 0,
     MemoryMap = 1,
     FrameBuffer = 2,
+    Acpi = 3,
 }
 
 #[repr(C, align(8))]
@@ -113,4 +114,13 @@ pub struct FrameBufferTag {
     pub red_byte: u8,
     pub green_byte: u8,
     pub blue_byte: u8,
+}
+
+#[repr(C, align(8))]
+#[derive(Debug, Clone, Copy)]
+pub struct AcpiTag {
+    pub tag_type: BootRequestTagType, // = BootRequestTagType::Acpi
+    pub size: u16,                    // 16 (64-bit) or 12 (32-bit)
+    pub flags: u16,
+    pub rsdt: usize,
 }

--- a/kernel.code-workspace
+++ b/kernel.code-workspace
@@ -5,7 +5,7 @@
         }
     ],
     "settings": {
-        "rust-analyzer.cargo.target": "x86_64-unknown-linux-gnu",
+        "rust-analyzer.cargo.target": "aarch64-unknown-linux-gnu",
         "rust-analyzer.check.command": "clippy",
         "rust-analyzer.check.targets": [
             "x86_64-unknown-linux-gnu",

--- a/kernel.code-workspace
+++ b/kernel.code-workspace
@@ -5,7 +5,7 @@
         }
     ],
     "settings": {
-        "rust-analyzer.cargo.target": "aarch64-unknown-linux-gnu",
+        "rust-analyzer.cargo.target": "x86_64-unknown-linux-gnu",
         "rust-analyzer.check.command": "clippy",
         "rust-analyzer.check.targets": [
             "x86_64-unknown-linux-gnu",

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -19,7 +19,7 @@ pub fn get_rsdt_address() -> Option<usize> {
         if ACPI_TAG.rsdt == 0 {
             None
         } else {
-            Some(ACPI_TAG.rsdt as usize)
+            Some(ACPI_TAG.rsdt)
         }
     }
 }

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -11,7 +11,7 @@ pub static mut ACPI_TAG: AcpiTag = AcpiTag {
     rsdt: 0,
 };
 
-pub fn get_rsdt_address() -> Option<usize> {
+pub fn get_root_table_address() -> Option<usize> {
     // # Safety
     // It's safe to access the tag structures since, although they are technically mutable, they only get changed by the bootloader.
     unsafe {

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -1,0 +1,25 @@
+use core::mem::size_of;
+
+use common::beryllium::{AcpiTag, BootRequestTagType};
+
+#[link_section = ".beryllium"]
+#[no_mangle]
+pub static mut ACPI_TAG: AcpiTag = AcpiTag {
+    tag_type: BootRequestTagType::Acpi,
+    size: size_of::<AcpiTag>() as u16,
+    flags: 0,
+    rsdt: 0,
+};
+
+pub fn get_rsdt_address() -> Option<usize> {
+    // # Safety
+    // Only the bootloader touches this value, so we should be safe.
+    // Additionally, this code only runs when the kernel is first loaded, so there are no threads to worry about.
+    unsafe {
+        if ACPI_TAG.rsdt == 0 {
+            None
+        } else {
+            Some(ACPI_TAG.rsdt as usize)
+        }
+    }
+}

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -13,8 +13,7 @@ pub static mut ACPI_TAG: AcpiTag = AcpiTag {
 
 pub fn get_rsdt_address() -> Option<usize> {
     // # Safety
-    // Only the bootloader touches this value, so we should be safe.
-    // Additionally, this code only runs when the kernel is first loaded, so there are no threads to worry about.
+    // It's safe to access the tag structures since, although they are technically mutable, they only get changed by the bootloader.
     unsafe {
         if ACPI_TAG.rsdt == 0 {
             None

--- a/kernel/src/aarch64/arch_api/mod.rs
+++ b/kernel/src/aarch64/arch_api/mod.rs
@@ -1,3 +1,4 @@
+pub mod acpi;
 pub mod init;
 pub mod paging;
 pub mod stack;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -53,6 +53,7 @@ extern "C" fn kmain() -> ! {
     physical_memory_manager::sanity_check();
     heap::sanity_check();
     console::println!("Initialized the display (obviously)");
+    console::println!("ACPI tables: {:#x?}", arch_api::acpi::get_rsdt_address());
     loop {}
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -53,7 +53,10 @@ extern "C" fn kmain() -> ! {
     physical_memory_manager::sanity_check();
     heap::sanity_check();
     console::println!("Initialized the display (obviously)");
-    console::println!("ACPI tables: {:#x?}", arch_api::acpi::get_rsdt_address());
+    console::println!(
+        "ACPI tables: {:#x?}",
+        arch_api::acpi::get_root_table_address()
+    );
     loop {}
 }
 

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -1,0 +1,15 @@
+static mut ACPI_ADDRESS: usize = 0;
+
+pub(in crate::arch) fn init(rsdt_address: usize) {
+    // # Safety
+    // This should only ever be called once, right at the start of the program. Therefore race conditions are impossible.
+    unsafe {
+        ACPI_ADDRESS = rsdt_address;
+    }
+}
+
+pub fn get_rsdt_address() -> usize {
+    // # Safety
+    // Se above for init.
+    unsafe { ACPI_ADDRESS }
+}

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -1,15 +1,15 @@
-static mut ACPI_ADDRESS: usize = 0;
+static mut ROOT_TABLE_ADDRESS: usize = 0;
 
 pub(in crate::arch) fn init(rsdt_address: usize) {
     // # Safety
-    // This should only ever be called once, right at the start of the program. Therefore race conditions are impossible.
+    // It is safe to assign to ROOT_TABLE_ADDRESS because this function is only called once, and then before threading is initialized.
     unsafe {
-        ACPI_ADDRESS = rsdt_address;
+        ROOT_TABLE_ADDRESS = rsdt_address;
     }
 }
 
-pub fn get_rsdt_address() -> usize {
+pub fn get_root_table_address() -> usize {
     // # Safety
     // Se above for init.
-    unsafe { ACPI_ADDRESS }
+    unsafe { ROOT_TABLE_ADDRESS }
 }

--- a/kernel/src/x86_64/arch_api/mod.rs
+++ b/kernel/src/x86_64/arch_api/mod.rs
@@ -1,2 +1,3 @@
+pub mod acpi;
 pub mod init;
 pub mod paging;

--- a/x86_64-config.sh
+++ b/x86_64-config.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 sed 's/aarch64/x86_64/g' -i .config
+sed 's/"rust-analyzer.cargo.target": "aarch64-unknown-linux-gnu"/"rust-analyzer.cargo.target": "x86_64-unknown-linux-gnu"/g' -i kernel.code-workspace


### PR DESCRIPTION
Adds code to find the address of the root ACPI table on both x86 and aarch64.

For Beryllium, I added another tag for fthe ACPI pointer, making the kernel-side logic very simple. For x86, I had to add code to handle the ACPI tags in the multiboot structures, which was a bit more involved.

The next thing to do will be to parse some of the basic static tables and use the information from them, including MP information and sort everything out from there.