### PR TITLE
Parse acpi tables

### DIFF
--- a/kernel/src/aarch64/acpi/gtdt.rs
+++ b/kernel/src/aarch64/acpi/gtdt.rs
@@ -1,3 +1,7 @@
+//! Generic Timer Description Table ([`GTDT`]) handling.
+//!
+//! [`GTDT`]: https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#generic-timer-description-table-gtdt
+
 use bitflags::bitflags;
 
 use crate::{

--- a/kernel/src/aarch64/acpi/gtdt.rs
+++ b/kernel/src/aarch64/acpi/gtdt.rs
@@ -28,7 +28,7 @@ struct GtdtTableBody {
 
 impl Validateable for GtdtTableBody {
     fn validate(&self) -> bool {
-        true // TODO: Actually validate this.
+        true // There isn't really anything to validate. We just need an implementation to use reinterpret_memory.
     }
 }
 

--- a/kernel/src/aarch64/acpi/gtdt.rs
+++ b/kernel/src/aarch64/acpi/gtdt.rs
@@ -1,0 +1,56 @@
+use bitflags::bitflags;
+
+use crate::{
+    acpi::AcpiTableHandle,
+    memory::{reinterpret_memory, Validateable},
+};
+
+#[repr(C, packed)]
+struct GtdtTableBody {
+    count_control_physical_address: u64,
+    reserved: u32,
+    _secure_el1_interrupt: u32,
+    _secure_el1_flags: u32,
+    el1_interrupt: u32,
+    el1_flags: u32,
+    _virtual_el1_interrupt: u32,
+    _virtual_el1_flags: u32,
+    _el2_interrupt: u32,
+    _el2_flags: u32,
+    counter_read_physical_address: u64,
+    platform_timers_count: u32,
+    platform_timers_offset: u32,
+}
+
+impl Validateable for GtdtTableBody {
+    fn validate(&self) -> bool {
+        true // TODO: Actually validate this.
+    }
+}
+
+bitflags! {
+    #[derive(Debug)]
+    pub struct TimerFlags : u32 {
+        const EDGE_TRIGGERED = 1 << 0;
+        const ACTIVE_LOW = 1 << 1;
+        const ALWAYS_ON = 1 << 2;
+    }
+}
+
+#[derive(Debug)]
+pub struct GtdtInfo {
+    pub timer_interrupt: u32,
+    pub timer_flags: TimerFlags,
+}
+
+impl GtdtInfo {
+    pub fn new(table: &AcpiTableHandle) -> Self {
+        assert_eq!(table.identifier(), b"GTDT");
+        let body = unsafe { reinterpret_memory::<GtdtTableBody>(table.body()) }
+            .expect("Invalid GTDT table body");
+        Self {
+            timer_interrupt: body.el1_interrupt,
+            timer_flags: TimerFlags::from_bits_retain(body.el1_flags),
+        }
+    }
+}

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 use alloc::vec::Vec;
 use common::beryllium::{AcpiTag, BootRequestTagType};
 
-use crate::acpi::{madt::MadtInfo, AcpiTableHandle};
+use crate::acpi::{fadt::FadtInfo, madt::MadtInfo, AcpiTableHandle};
 
 #[link_section = ".beryllium"]
 #[no_mangle]
@@ -28,15 +28,19 @@ pub fn get_root_table_address() -> Option<usize> {
 
 pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
     let mut madt = None;
+    let mut fadt = None;
     for table in acpi_tables {
         match table.identifier() {
             b"APIC" => {
-                crate::println!("Found madt with body size {}", table.body().len());
                 madt = Some(MadtInfo::new(&table));
+            }
+            b"FACP" => {
+                fadt = Some(FadtInfo::new(&table));
             }
             _ => {}
         }
     }
 
     crate::println!("MADT: {:?}", madt);
+    crate::println!("FADT: {:?}", fadt);
 }

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -31,6 +31,7 @@ pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
     for table in acpi_tables {
         match table.identifier() {
             b"APIC" => {
+                crate::println!("Found madt with body size {}", table.body().len());
                 madt = Some(MadtInfo::new(&table));
             }
             _ => {}

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -1,6 +1,9 @@
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use common::beryllium::{AcpiTag, BootRequestTagType};
+
+use crate::acpi::{madt::MadtInfo, AcpiTableHandle};
 
 #[link_section = ".beryllium"]
 #[no_mangle]
@@ -21,4 +24,18 @@ pub fn get_root_table_address() -> Option<usize> {
             Some(ACPI_TAG.rsdt)
         }
     }
+}
+
+pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
+    let mut madt = None;
+    for table in acpi_tables {
+        match table.identifier() {
+            b"APIC" => {
+                madt = Some(MadtInfo::new(&table));
+            }
+            _ => {}
+        }
+    }
+
+    crate::println!("MADT: {:?}", madt);
 }

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -3,7 +3,10 @@ use core::mem::size_of;
 use alloc::vec::Vec;
 use common::beryllium::{AcpiTag, BootRequestTagType};
 
-use crate::acpi::{fadt::FadtInfo, madt::MadtInfo, AcpiTableHandle};
+use crate::{
+    acpi::{fadt::FadtInfo, madt::MadtInfo, AcpiTableHandle},
+    arch::gtdt::GtdtInfo,
+};
 
 #[link_section = ".beryllium"]
 #[no_mangle]
@@ -29,6 +32,7 @@ pub fn get_root_table_address() -> Option<usize> {
 pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
     let mut madt = None;
     let mut fadt = None;
+    let mut gtdt = None;
     for table in acpi_tables {
         match table.identifier() {
             b"APIC" => {
@@ -37,10 +41,14 @@ pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
             b"FACP" => {
                 fadt = Some(FadtInfo::new(&table));
             }
+            b"GTDT" => {
+                gtdt = Some(GtdtInfo::new(&table));
+            }
             _ => {}
         }
     }
 
     crate::println!("MADT: {:?}", madt);
     crate::println!("FADT: {:?}", fadt);
+    crate::println!("GTDT: {:?}", gtdt);
 }

--- a/kernel/src/aarch64/mod.rs
+++ b/kernel/src/aarch64/mod.rs
@@ -2,3 +2,6 @@ pub mod arch_api;
 mod asm;
 mod exceptions;
 mod registers;
+
+#[path = "acpi/gtdt.rs"]
+mod gtdt;

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -144,8 +144,8 @@ pub fn find_required_acpi_tables() -> Result<Vec<AcpiTableHandle>, AcpiTableSear
         if table_body.len() % size_of::<u32>() != 0 {
             return Err(AcpiTableSearchError::InvalidRootTableSize);
         }
-        for table_address in table_body.chunks_exact(size_of::<u32>()) {
-            let table_address = unsafe { *(table_address.as_ptr() as *const u32) as usize };
+        for table_address in table_body.array_chunks::<{ size_of::<u32>() }>() {
+            let table_address = u32::from_le_bytes(*table_address) as usize;
             // # Safety
             // It is obviously safe to interpret the pointers in the RSDT as ACPI tables, since that is the point of the RSDT.
             let table = unsafe { AcpiTableHandle::new(table_address)? };
@@ -161,8 +161,8 @@ pub fn find_required_acpi_tables() -> Result<Vec<AcpiTableHandle>, AcpiTableSear
         if table_body.len() % size_of::<u64>() != 0 {
             return Err(AcpiTableSearchError::InvalidRootTableSize);
         }
-        for table_address in table_body.chunks_exact(size_of::<u64>()) {
-            let table_address = unsafe { *(table_address.as_ptr() as *const u64) as usize };
+        for table_address in table_body.array_chunks::<{ size_of::<u64>() }>() {
+            let table_address = u64::from_le_bytes(*table_address) as usize;
             // # Safety
             // It is obviously safe to interpret the pointers in the XSDT as ACPI tables, since that is the point of the XSDT.
             let table = unsafe { AcpiTableHandle::new(table_address) }?;

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -1,0 +1,174 @@
+use core::{
+    fmt::{self, Debug, Formatter},
+    mem::size_of,
+};
+
+use alloc::{string::String, vec::Vec};
+
+use crate::{
+    arch_api::{acpi, paging::MemoryType},
+    heap::{map_physical_memory, PhysicalAddressHandle},
+    memory::{reinterpret_memory, Validateable},
+    println,
+};
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct AcpiTableHeader {
+    identifier: [u8; 4],
+    length: u32,
+    revision: u8,
+    checksum: u8,
+    oem_id: [u8; 6],
+    oem_table_id: [u8; 8],
+    oem_revision: u32,
+    creator_id: u32,
+    creator_revision: u32,
+}
+
+const MAX_TABLE_SIZE: usize = 0x100_0000; // 16 MiB
+
+impl Validateable for AcpiTableHeader {
+    fn validate(&self) -> bool {
+        // I would like to check the checksum here, but unfortunately we would need the rest of the table for that.
+        // Instead we just check that the length is within a reasonable range.
+        self.length as usize >= size_of::<AcpiTableHeader>()
+            && self.length as usize <= MAX_TABLE_SIZE
+    }
+}
+
+pub struct AcpiTableHandle {
+    physical_memory_handle: PhysicalAddressHandle,
+    identifier: [u8; 4],
+}
+
+impl Debug for AcpiTableHandle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AcpiTableHandle")
+            .field("identifier", &self.identifier)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub enum AcpiTableParseError {
+    InvalidHeader,
+    ChecksumFailure,
+}
+
+impl AcpiTableHandle {
+    /// # Safety
+    /// If the provided address doesn't refer to an ACPI table, there will likely be undefined behaviour since it is impossible to tell at this point.
+    /// Additionally, it is UB if the table has already been mapped, since this would create possible aliasing issues.
+    pub unsafe fn new(physical_address: usize) -> Result<Self, AcpiTableParseError> {
+        let physical_memory_handle = map_physical_memory(
+            physical_address,
+            size_of::<AcpiTableHeader>(),
+            MemoryType::Normal,
+        );
+        let header = reinterpret_memory::<AcpiTableHeader>(&physical_memory_handle)
+            .ok_or(AcpiTableParseError::InvalidHeader)?;
+        let length = header.length as usize;
+        let identifier = header.identifier;
+        // To be certain that we don't map the same memory multiple times, we have to drop our handle before creating a new one.
+        drop(physical_memory_handle);
+        let physical_memory_handle =
+            map_physical_memory(physical_address, length, MemoryType::Normal);
+        // Check the checksum.
+        let sum = physical_memory_handle
+            .iter()
+            .fold(0u8, |acc, &x| acc.wrapping_add(x));
+        if sum != 0 {
+            Err(AcpiTableParseError::ChecksumFailure)
+        } else {
+            Ok(Self {
+                physical_memory_handle,
+                identifier,
+            })
+        }
+    }
+
+    pub fn identifier(&self) -> &[u8; 4] {
+        &self.identifier
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.physical_memory_handle
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.physical_memory_handle
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+const REQUIRED_TABLES: &[&[u8; 4]] = &[b"APIC"];
+#[cfg(target_arch = "x86_64")]
+const REQUIRED_TABLES: &[&[u8; 4]] = &[b"APIC", b"HPET"];
+
+#[derive(Debug)]
+pub enum AcpiTableSearchError {
+    NoRootTable,
+    InvalidRootTableSignature,
+    InvalidRootTableSize,
+    ParseError(AcpiTableParseError),
+}
+
+impl From<AcpiTableParseError> for AcpiTableSearchError {
+    fn from(error: AcpiTableParseError) -> Self {
+        Self::ParseError(error)
+    }
+}
+
+pub fn find_required_acpi_tables() -> Result<Vec<AcpiTableHandle>, AcpiTableSearchError> {
+    let root_table_address =
+        acpi::get_root_table_address().ok_or(AcpiTableSearchError::NoRootTable)?;
+        println!("Acpi tables at address {:#x}", root_table_address);
+    // # Safety
+    // The returned address is guaranteed to be valid, and we really don't have any choice but to trust it.
+    // Nothing else has used the address yet, so there shouldn't be any aliasing issues.
+    let root_table = unsafe { AcpiTableHandle::new(root_table_address) }?;
+    if root_table.identifier() != b"RSDT" && root_table.identifier() != b"XSDT" {
+        return Err(AcpiTableSearchError::InvalidRootTableSignature);
+    }
+    let table_body = &root_table.as_slice()[size_of::<AcpiTableHeader>()..];
+    if root_table.identifier() == b"RSDT" {
+        if table_body.len() % size_of::<u32>() != 0 {
+            return Err(AcpiTableSearchError::InvalidRootTableSize);
+        }
+        let mut tables = Vec::new();
+        for table_address in table_body.chunks_exact(size_of::<u32>()) {
+            let table_address = unsafe { *(table_address.as_ptr() as *const u32) as usize };
+            // # Safety
+            // It is obviously safe to interpret the pointers in the RSDT as ACPI tables, since that is the point of the RSDT.
+            let table = unsafe { AcpiTableHandle::new(table_address)? };
+            println!(
+                "Found table: {}",
+                String::from_utf8_lossy(table.identifier())
+            );
+            if REQUIRED_TABLES.contains(&table.identifier()) {
+                tables.push(table);
+            }
+        }
+        Ok(tables)
+    } else {
+        if table_body.len() % size_of::<u64>() != 0 {
+            return Err(AcpiTableSearchError::InvalidRootTableSize);
+        }
+        let mut tables = Vec::new();
+        for table_address in table_body.chunks_exact(size_of::<u64>()) {
+            let table_address = unsafe { *(table_address.as_ptr() as *const u64) as usize };
+            // # Safety
+            // It is obviously safe to interpret the pointers in the XSDT as ACPI tables, since that is the point of the XSDT.
+            let table = unsafe { AcpiTableHandle::new(table_address) }?;
+            println!(
+                "Found table: {}",
+                String::from_utf8_lossy(table.identifier())
+            );
+            if REQUIRED_TABLES.contains(&table.identifier()) {
+                tables.push(table);
+            }
+        }
+        Ok(tables)
+    }
+}

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -15,6 +15,7 @@ use crate::{
     println,
 };
 
+pub mod fadt;
 pub mod madt;
 
 #[derive(Debug, Clone, Copy)]

--- a/kernel/src/acpi/fadt.rs
+++ b/kernel/src/acpi/fadt.rs
@@ -22,7 +22,7 @@ pub struct FadtTableBody {
 
 impl Validateable for FadtTableBody {
     fn validate(&self) -> bool {
-        true // TODO: actually validate this structure
+        true // There isn't actually anything to validate.
     }
 }
 

--- a/kernel/src/acpi/fadt.rs
+++ b/kernel/src/acpi/fadt.rs
@@ -1,0 +1,88 @@
+use bitflags::bitflags;
+
+use crate::memory::{reinterpret_memory, Validateable};
+
+use super::AcpiTableHandle;
+
+#[repr(C, packed)]
+pub struct FadtTableBody {
+    // TODO: fill out the rest of this structure when we need it (which may well be never, since we are only dealing with early initialization code).
+    unknown: [u8; 73],
+    x86_boot_flags: u16,
+    reserved: u8,
+    fixed_flags: u32,
+    _reset_register: [u8; 12],
+    _reset_value: u8,
+    arm_boot_flags: u16,
+}
+
+impl Validateable for FadtTableBody {
+    fn validate(&self) -> bool {
+        true // TODO: actually validate this structure
+    }
+}
+
+bitflags! {
+    #[derive(Debug)]
+    pub struct X86BootFlags: u16 {
+        const LEGACY_DEVICES = 1 << 0;
+        const PS2_KEYBOARD = 1 << 1;
+        const VGA_NOT_PRESENT = 1 << 2;
+        const MSI_NOT_AVAILABLE = 1 << 3;
+        const ASPM_DISABLE = 1 << 4;
+        const CMOS_RTC_NOT_PRESENT = 1 << 5;
+    }
+
+    #[derive(Debug)]
+    pub struct FixedFlags: u32 {
+        const WBINVD_WORKS = 1 << 0;
+        const WBINVD_FLUSH = 1 << 1;
+        const C1_SUPPORTED = 1 << 2;
+        const C2_MULTIPROCESSORS = 1 << 3;
+        const POWER_BUTTON_IS_CONTROL_METHOD = 1 << 4;
+        const SLEEP_BUTTON_IS_CONTROL_METHOD = 1 << 5;
+        const RTC_WAKE_IS_FIXED = 1 << 6;
+        const RTC_WAKE_FROM_S4 = 1 << 7;
+        const TIMER_VALUE_32BIT = 1 << 8;
+        const CAN_BE_DOCKED = 1 << 9;
+        const RESET_REG_SUPPORTED = 1 << 10;
+        const SEALED_CASE = 1 << 11;
+        const HEADLESS = 1 << 12;
+        const REQUIRES_INSTRUCTION_AFTER_SLEEP_TYPE = 1 << 13;
+        const PCIE_WAKE = 1 << 14;
+        const USE_PLATFORM_CLOCK = 1 << 15;
+        const RTC_STATUS_VALID_FROM_S4 = 1 << 16;
+        const REMOTE_POWER_ON_CAPABLE = 1 << 17;
+        const FORCE_APIC_CLUSTER_MODEL = 1 << 18;
+        const FORCE_APIC_PHYSICAL_DESTINATION_MODE = 1 << 19;
+        const HW_REDUCED_ACPI = 1 << 20;
+        const S3_USELESS = 1 << 21;
+    }
+
+    #[derive(Debug)]
+    pub struct ArmBootFlags: u16 {
+        const SUPPORTS_PSCI = 1 << 0;
+        const MUST_USE_HVC = 1 << 1;
+    }
+}
+
+#[derive(Debug)]
+pub struct FadtInfo {
+    pub x86_boot_flags: X86BootFlags,
+    pub fixed_flags: FixedFlags,
+    pub arm_boot_flags: ArmBootFlags,
+}
+
+impl FadtInfo {
+    pub fn new(fadt_table: &AcpiTableHandle) -> Self {
+        assert_eq!(fadt_table.identifier(), b"FACP");
+        let fadt_table_body = unsafe { reinterpret_memory::<FadtTableBody>(fadt_table.body()) }
+            .expect("FADT table is invalid");
+
+        Self {
+            x86_boot_flags: X86BootFlags::from_bits_retain(fadt_table_body.x86_boot_flags),
+            fixed_flags: FixedFlags::from_bits_retain(fadt_table_body.fixed_flags),
+            arm_boot_flags: ArmBootFlags::from_bits_retain(fadt_table_body.arm_boot_flags),
+        }
+    }
+}

--- a/kernel/src/acpi/fadt.rs
+++ b/kernel/src/acpi/fadt.rs
@@ -1,3 +1,7 @@
+//! Fixed ACPI Description Table ([`FADT`]) handling.
+//!
+//! [`FADT`]: https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#fixed-acpi-description-table-fadt
+
 use bitflags::bitflags;
 
 use crate::memory::{reinterpret_memory, Validateable};

--- a/kernel/src/acpi/madt.rs
+++ b/kernel/src/acpi/madt.rs
@@ -1,3 +1,7 @@
+//! Multiple APIC Description Table (MADT) handling.
+//! 
+//! [`MADT`]: https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#multiple-apic-description-table-madt
+
 use alloc::vec::Vec;
 
 use crate::{

--- a/kernel/src/acpi/madt.rs
+++ b/kernel/src/acpi/madt.rs
@@ -1,0 +1,355 @@
+use alloc::vec::Vec;
+
+use crate::{
+    memory::{
+        reinterpret_memory, DynamicallySized, DynamicallySizedItem, DynamicallySizedObjectIterator,
+        Validateable,
+    },
+    println,
+};
+use core::mem::size_of;
+
+use super::AcpiTableHandle;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct MadtEntryHeader {
+    entry_type: u8,
+    length: u8,
+}
+
+impl DynamicallySized for MadtEntryHeader {
+    fn size(&self) -> usize {
+        self.length as usize
+    }
+}
+
+const MAX_ENTRY_SIZE: u8 = 64;
+
+impl Validateable for MadtEntryHeader {
+    fn validate(&self) -> bool {
+        self.length >= 2 && self.length <= MAX_ENTRY_SIZE
+    }
+}
+
+// It doesn't really make sense to use an enum for the type, since we don't know all the possible values (since the spec may change).
+const MADT_ENTRY_TYPE_LOCAL_APIC: u8 = 0;
+const MADT_ENTRY_TYPE_IO_APIC: u8 = 1;
+const MADT_ENTRY_TYPE_INTERRUPT_SOURCE_OVERRIDE: u8 = 2;
+const MADT_ENTRY_TYPE_NON_MASKABLE_INTERRUPT_SOURCE: u8 = 3;
+const MADT_ENTRY_TYPE_LOCAL_APIC_NMI: u8 = 4;
+const MADT_ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE: u8 = 5;
+const MADT_ENTRY_TYPE_IO_SAPIC: u8 = 6;
+const MADT_ENTRY_TYPE_LOCAL_SAPIC: u8 = 7;
+const MADT_TYPE_INTERRUPT_SOURCES: u8 = 8;
+const MADT_TYPE_LOCAL_X2APIC: u8 = 9;
+const MADT_TYPE_LOCAL_X2APIC_NMI: u8 = 0xa;
+const MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_CPU_INTERFACE: u8 = 0xb;
+const MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_DISTRIBUTOR: u8 = 0xc;
+const MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_MSI_FRAME: u8 = 0xd;
+const MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_REDISTRIBUTOR: u8 = 0xe;
+const MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_TRANSLATION_SERVICE: u8 = 0xf;
+
+macro_rules! default_operator {
+    ($left:expr, $default:tt|$given:tt, $right:expr) => {
+        $left $given $right
+    };
+    ($left:expr, $default:tt, $right:expr) => {
+        $left $default $right
+    };
+}
+
+macro_rules! madt_entry {
+    (
+        $(#[size_comparison_operator($size_comparison_operator:tt)])?
+        struct $Name:ident ($id:expr) {
+        $(
+            $field:ident: $Type:ty => $validation:expr
+    ),*$(,)?
+}
+) => {
+    #[derive(Debug, Clone, Copy)]
+    #[repr(C, packed)]
+    pub struct $Name {
+        header: MadtEntryHeader,
+        $(
+            $field: $Type,
+        )*
+    }
+
+impl $Name {
+    $(
+        pub fn $field(&self) -> $Type {
+            self.$field
+        }
+    )*
+}
+
+    impl Validateable for $Name {
+        fn validate(&self) -> bool {
+            #[allow(unused_variables)]
+            let $Name {header, $($field,)*} = *self;
+            header.validate() && header.entry_type == $id && default_operator!(header.length, ==$(|$size_comparison_operator)?, size_of::<Self>() as u8) && $(
+                $validation
+            )&&*
+        }
+    }
+}
+}
+
+madt_entry! {
+    struct LocalApicEntry(MADT_ENTRY_TYPE_LOCAL_APIC) {
+        acpi_id: u8 => true,
+        apic_id: u8 => true,
+        flags: u32 => true,
+    }
+}
+
+madt_entry! {
+    struct IoApicEntry(MADT_ENTRY_TYPE_IO_APIC) {
+        io_apic_id: u8 => true,
+        reserved: u8 => true,
+        io_apic_address: u32 => true,
+        global_system_interrupt_base: u32 => true,
+    }
+}
+
+madt_entry! {
+    struct InterruptSourceOverrideEntry(MADT_ENTRY_TYPE_INTERRUPT_SOURCE_OVERRIDE) {
+        bus_source: u8 => true,
+        irq_source: u8 => true,
+        global_system_interrupt: u32 => true,
+        flags: u16 => true,
+    }
+}
+
+madt_entry! {
+    struct NonMaskableInterruptSourceEntry(MADT_ENTRY_TYPE_NON_MASKABLE_INTERRUPT_SOURCE) {
+        flags: u16 => true,
+        global_system_interrupt: u32 => true,
+    }
+}
+
+madt_entry! {
+    struct LocalApicNmiEntry(MADT_ENTRY_TYPE_LOCAL_APIC_NMI) {
+        acpi_processor_id: u8 => true,
+        flags: u16 => true,
+        local_apic_lint: u8 => true,
+    }
+}
+
+madt_entry! {
+    struct LocalApicAddressOverrideEntry(MADT_ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE) {
+        reserved: u16 => true,
+        local_apic_address: u64 => true,
+    }
+}
+
+madt_entry! {
+    struct IoSapicEntry(MADT_ENTRY_TYPE_IO_SAPIC) {
+        io_sapic_id: u8 => true,
+        reserved: u8 => true,
+        global_system_interrupt_base: u32 => true,
+        io_sapic_address: u64 => true,
+    }
+}
+
+madt_entry! {
+    #[size_comparison_operator(>=)]
+    struct LocalSapicEntry(MADT_ENTRY_TYPE_LOCAL_SAPIC) {
+        acpi_processor_id: u8 => true,
+        local_sapic_id: u8 => true,
+        local_sapic_eid: u8 => true,
+        reserved: [u8; 3] => true,
+        flags: u32 => true,
+        acpi_processor_uid_string: u8 => true,
+    }
+}
+
+madt_entry! {
+    struct InterruptSourceEntry(MADT_TYPE_INTERRUPT_SOURCES) {
+        flags: u16 => true,
+        interrupt_type: u8 => true,
+        destination_processor_id: u8 => true,
+        destination_processor_eid: u8 => true,
+        sapic_vector: u8 => true,
+        global_system_interrupt: u32 => true,
+        platform_flags: u32 => true,
+    }
+}
+
+madt_entry! {
+    struct LocalX2ApicEntry(MADT_TYPE_LOCAL_X2APIC) {
+        reserved: u16 => true,
+        x2apic_id: u32 => true,
+        flags: u32 => true,
+        acpi_processor_uid: u32 => true,
+    }
+}
+
+madt_entry! {
+    struct LocalX2ApicNmiEntry(MADT_TYPE_LOCAL_X2APIC_NMI) {
+        flags: u16 => true,
+        acpi_processor_uid: u32 => true,
+        local_x2apic_lint: u8 => true,
+        reserved: [u8; 3] => true,
+    }
+}
+
+madt_entry! {
+    struct GenericInterruptControllerCpuInterfaceEntry(MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_CPU_INTERFACE) {
+        reserved: u16 => true,
+        cpu_interface_number: u32 => true,
+        uid: u32 => true,
+        flags: u32 => true,
+        parking_protocol_version: u32 => true,
+        performance_interrupt: u32 => true,
+        parked_address: u64 => true,
+        base_address: u64 => true,
+        gicv_base_address: u64 => true,
+        gich_base_address: u64 => true,
+        vgic_maintenance_interrupt: u32 => true,
+        gicr_base_address: u64 => true,
+        multiprocessing_id: u64 => true,
+        processor_efficiency: u8 => true,
+        reserved2: u8 => true,
+        statistical_profiling_interrupt: u16 => true,
+    }
+}
+
+madt_entry! {
+    struct GenericInterruptControllerDistributorEntry(MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_DISTRIBUTOR) {
+        reserved: u16 => true,
+        gic_id: u32 => true,
+        base_address: u64 => true,
+        global_system_interrupt_base: u32 => true, // Always 0
+        version: u8 => true,
+        reserved2: [u8; 3] => true,
+    }
+}
+
+madt_entry! {
+    struct GenericInterruptControllerMsiFrameEntry(MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_MSI_FRAME) {
+        reserved: u16 => true,
+        msi_frame_id: u32 => true,
+        base_address: u64 => true,
+        flags: u32 => true,
+        spi_count: u16 => true,
+        spi_base: u16 => true,
+    }
+}
+
+madt_entry! {
+    struct GenericInterruptControllerRedistributorEntry(MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_REDISTRIBUTOR) {
+        reserved: u16 => true,
+        discovery_range_base_address: u64 => true,
+        discovery_range_length: u32 => true,
+    }
+}
+
+madt_entry! {
+    struct GenericInterruptControllerTranslationServiceEntry(MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_TRANSLATION_SERVICE) {
+        reserved: u16 => true,
+        translation_service_id: u32 => true,
+        base_address: u64 => true,
+        reserved2: u32 => true,
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MadtInfo {
+    pub local_apic_address: u32,
+    pub flags: u32,
+
+    // We essentially have a Vec of each of the types defined above.
+    pub local_apic_entries: Vec<LocalApicEntry>,
+    pub io_apic_entries: Vec<IoApicEntry>,
+    pub interrupt_source_override_entries: Vec<InterruptSourceOverrideEntry>,
+    pub non_maskable_interrupt_source_entries: Vec<NonMaskableInterruptSourceEntry>,
+    pub local_apic_nmi_entries: Vec<LocalApicNmiEntry>,
+    pub local_apic_address_override_entries: Vec<LocalApicAddressOverrideEntry>,
+    pub io_sapic_entries: Vec<IoSapicEntry>,
+    pub local_sapic_entries: Vec<LocalSapicEntry>,
+    pub interrupt_source_entries: Vec<InterruptSourceEntry>,
+    pub local_x2apic_entries: Vec<LocalX2ApicEntry>,
+    pub local_x2apic_nmi_entries: Vec<LocalX2ApicNmiEntry>,
+    pub generic_interrupt_controller_cpu_interface_entries:
+        Vec<GenericInterruptControllerCpuInterfaceEntry>,
+    pub generic_interrupt_controller_distributor_entries:
+        Vec<GenericInterruptControllerDistributorEntry>,
+    pub generic_interrupt_controller_msi_frame_entries:
+        Vec<GenericInterruptControllerMsiFrameEntry>,
+    pub generic_interrupt_controller_redistributor_entries:
+        Vec<GenericInterruptControllerRedistributorEntry>,
+    pub generic_interrupt_controller_translation_service_entries:
+        Vec<GenericInterruptControllerTranslationServiceEntry>,
+}
+
+impl MadtInfo {
+    pub fn new(table: &AcpiTableHandle) -> Self {
+        assert_eq!(table.identifier(), b"APIC");
+        let body = table.body();
+        // The first eight bytes of the body are the local APIC address and the flags.
+        let local_apic_address = u32::from_le_bytes(body[0..4].try_into().unwrap());
+        let flags = u32::from_le_bytes(body[4..8].try_into().unwrap());
+
+        let mut result = MadtInfo {
+            local_apic_address,
+            flags,
+            ..Default::default()
+        };
+
+        let entries_data = &body[8..];
+        for DynamicallySizedItem {
+            value,
+            value_memory,
+        } in DynamicallySizedObjectIterator::<MadtEntryHeader>::new(entries_data)
+        {
+            macro_rules! add_entry {
+    ($list_name:ident) => {
+        result.$list_name.push(
+            *unsafe {reinterpret_memory(value_memory)
+                .expect("Invalid MADT entry")
+        })
+}
+            }
+
+            match value.entry_type {
+                MADT_ENTRY_TYPE_LOCAL_APIC => add_entry!(local_apic_entries),
+                MADT_ENTRY_TYPE_IO_APIC => add_entry!(io_apic_entries),
+                MADT_ENTRY_TYPE_INTERRUPT_SOURCE_OVERRIDE => {
+                    add_entry!(interrupt_source_override_entries)
+                }
+                MADT_ENTRY_TYPE_NON_MASKABLE_INTERRUPT_SOURCE => {
+                    add_entry!(non_maskable_interrupt_source_entries)
+                }
+                MADT_ENTRY_TYPE_LOCAL_APIC_NMI => add_entry!(local_apic_nmi_entries),
+                MADT_ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE => {
+                    add_entry!(local_apic_address_override_entries)
+                }
+                MADT_ENTRY_TYPE_IO_SAPIC => add_entry!(io_sapic_entries),
+                MADT_ENTRY_TYPE_LOCAL_SAPIC => add_entry!(local_sapic_entries),
+                MADT_TYPE_INTERRUPT_SOURCES => add_entry!(interrupt_source_entries),
+                MADT_TYPE_LOCAL_X2APIC => add_entry!(local_x2apic_entries),
+                MADT_TYPE_LOCAL_X2APIC_NMI => add_entry!(local_x2apic_nmi_entries),
+                MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_CPU_INTERFACE => {
+                    add_entry!(generic_interrupt_controller_cpu_interface_entries)
+                }
+                MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_DISTRIBUTOR => {
+                    add_entry!(generic_interrupt_controller_distributor_entries)
+                }
+                MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_MSI_FRAME => {
+                    add_entry!(generic_interrupt_controller_msi_frame_entries)
+                }
+                MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_REDISTRIBUTOR => {
+                    add_entry!(generic_interrupt_controller_redistributor_entries)
+                }
+                MADT_TYPE_GENERIC_INTERRUPT_CONTROLLER_TRANSLATION_SERVICE => {
+                    add_entry!(generic_interrupt_controller_translation_service_entries)
+                }
+                _ => println!("Unknown MADT entry type: {}", value.entry_type),
+            }
+        }
+        result
+    }
+}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -15,6 +15,7 @@
     let_chains,
     new_uninit,
     asm_const,
+    array_chunks
 )]
 // Shut up the compiler about const generic expressions.
 #![allow(incomplete_features)]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -21,6 +21,7 @@
 // While I don't enjoy surpressing warnings, I think that this particular warning is unnecessary at this stage of development. It would be more useful when the basic components are in place and working.
 #![allow(dead_code)]
 
+mod acpi;
 mod assert;
 mod buddy;
 mod console;
@@ -53,10 +54,8 @@ extern "C" fn kmain() -> ! {
     physical_memory_manager::sanity_check();
     heap::sanity_check();
     console::println!("Initialized the display (obviously)");
-    console::println!(
-        "ACPI tables: {:#x?}",
-        arch_api::acpi::get_root_table_address()
-    );
+    let required_acpi_tables = acpi::find_required_acpi_tables().unwrap();
+    console::println!("Found required ACPI tables: {:?}", required_acpi_tables);
     loop {}
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -55,7 +55,7 @@ extern "C" fn kmain() -> ! {
     heap::sanity_check();
     console::println!("Initialized the display (obviously)");
     let required_acpi_tables = acpi::find_required_acpi_tables().unwrap();
-    console::println!("Found required ACPI tables: {:?}", required_acpi_tables);
+    arch_api::acpi::handle_acpi_info(required_acpi_tables);
     loop {}
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -15,7 +15,8 @@
     let_chains,
     new_uninit,
     asm_const,
-    array_chunks
+    array_chunks,
+    offset_of,
 )]
 // Shut up the compiler about const generic expressions.
 #![allow(incomplete_features)]

--- a/kernel/src/memory.rs
+++ b/kernel/src/memory.rs
@@ -190,8 +190,10 @@ pub trait DynamicallySized {
 
 impl<T: DynamicallySized> DynamicallySized for &T {
     fn size(&self) -> usize {
-        (*self).size()
+        (**self).size()
     }
+
+    const ALIGNMENT: usize = T::ALIGNMENT;
 }
 
 pub struct DynamicallySizedItem<'lifetime, T: DynamicallySized> {
@@ -231,7 +233,7 @@ where
             return None;
         }
         let value_memory = &self.total_memory[self.current_offset..];
-        let value: T = T::from_bytes(self.endianness, value_memory)
+        let value = T::from_bytes(self.endianness, value_memory)
             .expect("Failed to create object from memory");
         if value.size() > self.total_memory.len() - self.current_offset {
             return None;

--- a/kernel/src/x86_64/acpi/hpet.rs
+++ b/kernel/src/x86_64/acpi/hpet.rs
@@ -1,0 +1,52 @@
+use crate::{
+    acpi::AcpiTableHandle,
+    memory::{reinterpret_memory, Validateable},
+};
+
+#[repr(C, packed)]
+pub struct HpetTableBody {
+    hardware_revision: u8,
+    counter_info: u8,
+    pci_vendor_id: u16,
+    address_space: u8,
+    bit_width: u8,
+    bit_offset: u8,
+    access_width: u8,
+    address: u64,
+    hpet_number: u8,
+    minimum_tick: u16,
+    page_protection: u8,
+}
+
+impl Validateable for HpetTableBody {
+    fn validate(&self) -> bool {
+        true // TODO: Actually validate this
+    }
+}
+
+const COUNTER_INFO_COMPARATOR_COUNT_MASK: u8 = 0b0001_1111;
+const COUNTER_INFO_64_BIT: u8 = 0b0010_0000;
+const COUNTER_INFO_LEGACY_REPLACEMENT: u8 = 0b1000_0000;
+
+#[derive(Debug)]
+pub struct HpetInfo {
+    pub address: u64,
+    pub comparator_count: u8,
+    pub is_64_bit: bool,
+    pub legacy_replacement: bool,
+}
+
+impl HpetInfo {
+    pub fn new(table: &AcpiTableHandle) -> HpetInfo {
+        assert_eq!(table.identifier(), b"HPET");
+        let body = unsafe { reinterpret_memory::<HpetTableBody>(table.body()) }
+            .expect("Invalid HPET table");
+        let counter_info = body.counter_info;
+        Self {
+            address: body.address,
+            comparator_count: (counter_info & COUNTER_INFO_COMPARATOR_COUNT_MASK) + 1,
+            is_64_bit: counter_info & COUNTER_INFO_64_BIT != 0,
+            legacy_replacement: counter_info & COUNTER_INFO_LEGACY_REPLACEMENT != 0,
+        }
+    }
+}

--- a/kernel/src/x86_64/acpi/hpet.rs
+++ b/kernel/src/x86_64/acpi/hpet.rs
@@ -1,3 +1,7 @@
+//! High Precision Event Timer ([`HPET`]) table handling.
+//!
+//! [`HPET`]: https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/software-developers-hpet-spec-1-0a.pdf
+
 use crate::{
     acpi::AcpiTableHandle,
     memory::{reinterpret_memory, Validateable},

--- a/kernel/src/x86_64/acpi/hpet.rs
+++ b/kernel/src/x86_64/acpi/hpet.rs
@@ -24,7 +24,7 @@ pub struct HpetTableBody {
 
 impl Validateable for HpetTableBody {
     fn validate(&self) -> bool {
-        true // TODO: Actually validate this
+        true // There isn't really much to validate here. However, it's needed to allow us to reinterpret_memory.
     }
 }
 

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -8,8 +8,14 @@ pub(in crate::arch) fn init(rsdt_address: usize) {
     }
 }
 
-pub fn get_root_table_address() -> usize {
+pub fn get_root_table_address() -> Option<usize> {
     // # Safety
     // Se above for init.
-    unsafe { ROOT_TABLE_ADDRESS }
+    unsafe {
+        if ROOT_TABLE_ADDRESS == 0 {
+            None
+        } else {
+            Some(ROOT_TABLE_ADDRESS)
+        }
+    }
 }

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -1,3 +1,7 @@
+use alloc::vec::Vec;
+
+use crate::acpi::{madt::MadtInfo, AcpiTableHandle};
+
 static mut ROOT_TABLE_ADDRESS: usize = 0;
 
 pub(in crate::arch) fn init(rsdt_address: usize) {
@@ -18,4 +22,18 @@ pub fn get_root_table_address() -> Option<usize> {
             Some(ROOT_TABLE_ADDRESS)
         }
     }
+}
+
+pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
+    let mut madt = None;
+    for table in acpi_tables {
+        match table.identifier() {
+            b"APIC" => {
+                madt = Some(MadtInfo::new(&table));
+            }
+            _ => {}
+        }
+    }
+
+    crate::println!("MADT: {:?}", madt);
 }

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -1,6 +1,9 @@
 use alloc::vec::Vec;
 
-use crate::acpi::{madt::MadtInfo, AcpiTableHandle};
+use crate::{
+    acpi::{madt::MadtInfo, AcpiTableHandle},
+    arch::hpet::HpetInfo,
+};
 
 static mut ROOT_TABLE_ADDRESS: usize = 0;
 
@@ -26,14 +29,19 @@ pub fn get_root_table_address() -> Option<usize> {
 
 pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
     let mut madt = None;
+    let mut hpet = None;
     for table in acpi_tables {
         match table.identifier() {
             b"APIC" => {
                 madt = Some(MadtInfo::new(&table));
+            }
+            b"HPET" => {
+                hpet = Some(HpetInfo::new(&table));
             }
             _ => {}
         }
     }
 
     crate::println!("MADT: {:?}", madt);
+    crate::println!("HPET: {:?}", hpet);
 }

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -1,3 +1,6 @@
 pub mod arch_api;
 mod interrupts;
 mod multiboot;
+
+#[path = "acpi/hpet.rs"]
+mod hpet;

--- a/kernel/src/x86_64/multiboot.rs
+++ b/kernel/src/x86_64/multiboot.rs
@@ -244,11 +244,15 @@ fn parse_frame_buffer(frame_buffer: &MbiFrameBufferTag) {
             green_byte: frame_buffer.green_position / 8,
             blue_byte: frame_buffer.blue_position / 8,
             pixels: {
-                let physical_address_handle = map_physical_memory(
-                    frame_buffer.address as usize,
-                    frame_buffer.pitch as usize * frame_buffer.height as usize,
-                    MemoryType::Device,
-                );
+                // # Safety
+                // This is the only place where the framebuffer is mapped, so there should be no aliasing issues.
+                let physical_address_handle = unsafe {
+                    map_physical_memory(
+                        frame_buffer.address as usize,
+                        frame_buffer.pitch as usize * frame_buffer.height as usize,
+                        MemoryType::Device,
+                    )
+                };
                 PhysicalAddressHandle::leak(physical_address_handle)
             },
         });

--- a/kernel/src/x86_64/multiboot.rs
+++ b/kernel/src/x86_64/multiboot.rs
@@ -190,6 +190,7 @@ pub fn parse_multiboot_structures() {
                     unsafe { reinterpret_memory(tag_memory).unwrap() };
                 acpi::init(acpi_new_tag.xsdt_address as usize);
             }
+            0 => break, // End of tags
             _ => {}
         }
     }

--- a/kernel/src/x86_64/multiboot.rs
+++ b/kernel/src/x86_64/multiboot.rs
@@ -5,7 +5,8 @@ use crate::{
     heap::{map_physical_memory, PhysicalAddressHandle},
     memory::{
         align_address_down, align_address_up, reinterpret_memory, slice_from_memory,
-        DynamicallySized, DynamicallySizedItem, DynamicallySizedObjectIterator, Validateable,
+        DynamicallySized, DynamicallySizedItem, DynamicallySizedObjectIterator, Endianness,
+        Validateable,
     },
     physical_memory_manager::{mark_range_as_free, BLOCK_SIZE},
 };
@@ -157,8 +158,8 @@ pub fn parse_multiboot_structures() {
         )
         .unwrap()
     };
-    let tag_iterator: DynamicallySizedObjectIterator<MbiTag> =
-        DynamicallySizedObjectIterator::new(tag_memory);
+    let tag_iterator: DynamicallySizedObjectIterator<&MbiTag> =
+        DynamicallySizedObjectIterator::new(Endianness::Little, tag_memory);
     let mut frame_buffer = None; // Delayed initialization to allow for memory to be detected first.
     let mut found_new_acpi = false;
     for DynamicallySizedItem {


### PR DESCRIPTION
This adds code to parse all of the important (as far as I can predict) ACPI tables for kernel initialization. On aarch64, this means the XSDT/RSDT, MADT, FADT and GTDT. On x86_64, it is the XSDT/RSDT, MADT and HPET.

So far, all it does with the information is print it to the screen. The next thing to do will be to make it set up timers and (eventually) initialize secondary processors.