### PR TITLE
Initialize timers

### DIFF
--- a/kernel/src/aarch64/acpi/gtdt.rs
+++ b/kernel/src/aarch64/acpi/gtdt.rs
@@ -14,12 +14,13 @@ memory_struct! {
 struct GtdtTableBody<'lifetime> {
     count_control_physical_address: u64,
     reserved: u32,
+    // We only use the virtual EL1 timer here.
     _secure_el1_interrupt: u32,
     _secure_el1_flags: u32,
-    el1_interrupt: u32,
-    el1_flags: u32,
-    _virtual_el1_interrupt: u32,
-    _virtual_el1_flags: u32,
+    _el1_interrupt: u32,
+    _el1_flags: u32,
+    virtual_el1_interrupt: u32,
+    virtual_el1_flags: u32,
     _el2_interrupt: u32,
     _el2_flags: u32,
     counter_read_physical_address: u64,
@@ -49,8 +50,8 @@ impl GtdtInfo {
         let body = GtdtTableBody::from_bytes(Endianness::Little, table.body())
             .expect("Invalid GTDT table body");
         Self {
-            timer_interrupt: body.el1_interrupt(),
-            timer_flags: TimerFlags::from_bits_retain(body.el1_flags()),
+            timer_interrupt: body.virtual_el1_interrupt(),
+            timer_flags: TimerFlags::from_bits_retain(body.virtual_el1_flags()),
         }
     }
 }

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -30,9 +30,9 @@ pub fn get_root_table_address() -> Option<usize> {
 }
 
 pub struct AcpiInfo {
-    madt: MadtInfo,
-    fadt: FadtInfo,
-    gtdt: GtdtInfo,
+    pub madt: MadtInfo,
+    pub fadt: FadtInfo,
+    pub gtdt: GtdtInfo,
 }
 
 pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) -> AcpiInfo {

--- a/kernel/src/aarch64/arch_api/acpi.rs
+++ b/kernel/src/aarch64/arch_api/acpi.rs
@@ -29,7 +29,13 @@ pub fn get_root_table_address() -> Option<usize> {
     }
 }
 
-pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
+pub struct AcpiInfo {
+    madt: MadtInfo,
+    fadt: FadtInfo,
+    gtdt: GtdtInfo,
+}
+
+pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) -> AcpiInfo {
     let mut madt = None;
     let mut fadt = None;
     let mut gtdt = None;
@@ -51,4 +57,10 @@ pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
     crate::println!("MADT: {:?}", madt);
     crate::println!("FADT: {:?}", fadt);
     crate::println!("GTDT: {:?}", gtdt);
+
+    AcpiInfo {
+        madt: madt.expect("MADT not found"),
+        fadt: fadt.expect("FADT not found"),
+        gtdt: gtdt.expect("GTDT not found"),
+    }
 }

--- a/kernel/src/aarch64/arch_api/asm.rs
+++ b/kernel/src/aarch64/arch_api/asm.rs
@@ -1,0 +1,7 @@
+use core::arch::asm;
+
+pub fn memory_barrier() {
+    unsafe {
+        asm!("dmb sy");
+    }
+}

--- a/kernel/src/aarch64/arch_api/irq.rs
+++ b/kernel/src/aarch64/arch_api/irq.rs
@@ -1,0 +1,3 @@
+use super::acpi::AcpiInfo;
+
+pub fn initialize(acpi_info: &AcpiInfo) {}

--- a/kernel/src/aarch64/arch_api/irq.rs
+++ b/kernel/src/aarch64/arch_api/irq.rs
@@ -1,3 +1,84 @@
+use alloc::boxed::Box;
+
+use crate::arch::gicv2::Gicv2;
+
 use super::acpi::AcpiInfo;
 
-pub fn initialize(acpi_info: &AcpiInfo) {}
+pub(in crate::arch) struct InterruptInfo {
+    pub interrupt_number: u32,
+
+    pub acknowledge_register_value: u32,
+}
+
+pub(in crate::arch) trait GenericInterruptController {
+    /// Acknowledge that an interrupt was received, getting the interrupt number at the same time.
+    /// On GICv2, this is done by reading the `IAR` register in the CPU interface.
+    fn acknowledge_interrupt(&mut self) -> Option<InterruptInfo>;
+
+    /// Signal the end of interrupt handling, providing the interrupt number.
+    fn end_of_interrupt(&mut self, interrupt_info: InterruptInfo);
+
+    fn enable_interrupt(&mut self, interrupt_number: u32);
+    fn disable_interrupt(&mut self, interrupt_number: u32);
+
+    fn interrupt_is_usable(&self, interrupt_number: u32) -> bool;
+
+    /// Enables the interrupts for this CPU.
+    /// On GICV2, this means enabling the CPU interface.
+    fn enable_interrupts_for_this_cpu(&mut self);
+}
+
+static mut GIC: Option<Box<dyn GenericInterruptController>> = None;
+
+pub fn initialize(acpi_info: &AcpiInfo) {
+    assert!(
+        !acpi_info
+            .madt
+            .generic_interrupt_controller_distributor_entries
+            .is_empty(),
+        "No GICD entries found in MADT"
+    );
+    // Since there should only be one distributor, we just get it here.
+    let gic_distributor = &acpi_info
+        .madt
+        .generic_interrupt_controller_distributor_entries[0];
+
+    if gic_distributor.gic_version == 2 {
+        assert!(
+            !acpi_info
+                .madt
+                .generic_interrupt_controller_cpu_interface_entries
+                .is_empty(),
+            "No GICC entries found in MADT"
+        );
+
+        let distributor_address = gic_distributor.base_address;
+        let cpu_interface_address = acpi_info
+            .madt
+            .generic_interrupt_controller_cpu_interface_entries[0]
+            .base_address;
+
+        // The GICV2 spec "strongly recommends" that the CPU interface address is common, so we
+        // assert that here.
+        for cpu_interface_entry in &acpi_info
+            .madt
+            .generic_interrupt_controller_cpu_interface_entries
+        {
+            assert_eq!(
+                cpu_interface_entry.base_address, cpu_interface_address,
+                "GICV2 CPU interface address is not common"
+            );
+        }
+
+        // SAFETY: The provided addresses are from ACPI, so they are correct.
+        // Also, there are no other GIC drivers running at this point, so there will be no conflicts.
+        unsafe {
+            GIC = Some(Box::new(Gicv2::new(
+                distributor_address as usize,
+                cpu_interface_address as usize,
+            )));
+        }
+    } else {
+        panic!("GICv{} not supported yet", gic_distributor.gic_version);
+    }
+}

--- a/kernel/src/aarch64/arch_api/irq.rs
+++ b/kernel/src/aarch64/arch_api/irq.rs
@@ -10,6 +10,12 @@ pub(in crate::arch) struct InterruptInfo {
     pub acknowledge_register_value: u32,
 }
 
+pub(in crate::arch) enum Priority {
+    Low,
+    Normal,
+    High,
+}
+
 pub(in crate::arch) trait GenericInterruptController {
     /// Acknowledge that an interrupt was received, getting the interrupt number at the same time.
     /// On GICv2, this is done by reading the `IAR` register in the CPU interface.
@@ -21,7 +27,12 @@ pub(in crate::arch) trait GenericInterruptController {
     fn enable_interrupt(&mut self, interrupt_number: u32);
     fn disable_interrupt(&mut self, interrupt_number: u32);
 
-    fn configure_interrupt(&mut self, interrupt_number: u32, edge_triggered: bool, priority: u8);
+    fn configure_interrupt(
+        &mut self,
+        interrupt_number: u32,
+        edge_triggered: bool,
+        priority: Priority,
+    );
 
     fn interrupt_is_usable(&self, interrupt_number: u32) -> bool;
 
@@ -111,7 +122,7 @@ pub(in crate::arch) fn disable_interrupt(interrupt_number: u32) {
 pub(in crate::arch) fn configure_interrupt(
     interrupt_number: u32,
     edge_triggered: bool,
-    priority: u8,
+    priority: Priority,
 ) {
     // SAFETY: The GIC is designed to work across threads.
     unsafe {

--- a/kernel/src/aarch64/arch_api/mod.rs
+++ b/kernel/src/aarch64/arch_api/mod.rs
@@ -2,3 +2,4 @@ pub mod acpi;
 pub mod init;
 pub mod paging;
 pub mod stack;
+pub mod timer;

--- a/kernel/src/aarch64/arch_api/mod.rs
+++ b/kernel/src/aarch64/arch_api/mod.rs
@@ -1,4 +1,5 @@
 pub mod acpi;
+pub mod asm;
 pub mod init;
 pub mod paging;
 pub mod stack;

--- a/kernel/src/aarch64/arch_api/mod.rs
+++ b/kernel/src/aarch64/arch_api/mod.rs
@@ -1,6 +1,7 @@
 pub mod acpi;
 pub mod asm;
 pub mod init;
+pub mod irq;
 pub mod paging;
 pub mod stack;
 pub mod timer;

--- a/kernel/src/aarch64/arch_api/timer.rs
+++ b/kernel/src/aarch64/arch_api/timer.rs
@@ -1,0 +1,11 @@
+use crate::arch::registers::{get_cntfrq, get_cntvct};
+
+use super::acpi::AcpiInfo;
+
+pub fn initialize(acpi_info: &AcpiInfo) {
+    let timer_frequency = get_cntfrq();
+    loop {
+        let start = get_cntvct();
+        while get_cntvct() - start < timer_frequency {}
+    }
+}

--- a/kernel/src/aarch64/arch_api/timer.rs
+++ b/kernel/src/aarch64/arch_api/timer.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::{AtomicU32, Ordering};
+
 use crate::arch::{
     gtdt::TimerFlags,
     registers::{get_cntfrq, get_cntvct, set_cntv_ctl, set_cntv_cval},
@@ -7,6 +9,8 @@ use super::{
     acpi::AcpiInfo,
     irq::{configure_interrupt, enable_interrupt, Priority},
 };
+
+static TIMER_INTERRUPT: AtomicU32 = AtomicU32::new(0);
 
 pub fn initialize(acpi_info: &AcpiInfo) {
     let timer_frequency = get_cntfrq();
@@ -21,4 +25,10 @@ pub fn initialize(acpi_info: &AcpiInfo) {
         Priority::High,
     );
     enable_interrupt(acpi_info.gtdt.timer_interrupt);
+
+    TIMER_INTERRUPT.store(acpi_info.gtdt.timer_interrupt, Ordering::SeqCst);
+}
+
+pub(in crate::arch) fn get_timer_interrupt() -> u32 {
+    TIMER_INTERRUPT.load(Ordering::SeqCst)
 }

--- a/kernel/src/aarch64/arch_api/timer.rs
+++ b/kernel/src/aarch64/arch_api/timer.rs
@@ -1,4 +1,10 @@
-use crate::arch::registers::{get_cntfrq, get_cntvct};
+use crate::{
+    arch::{
+        asm::yield_instruction,
+        registers::{get_cntfrq, get_cntvct},
+    },
+    print,
+};
 
 use super::acpi::AcpiInfo;
 
@@ -6,6 +12,9 @@ pub fn initialize(acpi_info: &AcpiInfo) {
     let timer_frequency = get_cntfrq();
     loop {
         let start = get_cntvct();
-        while get_cntvct() - start < timer_frequency {}
+        while get_cntvct() - start < timer_frequency {
+            yield_instruction(); // ?
+        }
+        print!(".");
     }
 }

--- a/kernel/src/aarch64/arch_api/timer.rs
+++ b/kernel/src/aarch64/arch_api/timer.rs
@@ -5,7 +5,7 @@ use crate::arch::{
 
 use super::{
     acpi::AcpiInfo,
-    irq::{configure_interrupt, enable_interrupt},
+    irq::{configure_interrupt, enable_interrupt, Priority},
 };
 
 pub fn initialize(acpi_info: &AcpiInfo) {
@@ -18,7 +18,7 @@ pub fn initialize(acpi_info: &AcpiInfo) {
             .gtdt
             .timer_flags
             .contains(TimerFlags::EDGE_TRIGGERED),
-        0xf0,
+        Priority::High,
     );
     enable_interrupt(acpi_info.gtdt.timer_interrupt);
 }

--- a/kernel/src/aarch64/arch_api/timer.rs
+++ b/kernel/src/aarch64/arch_api/timer.rs
@@ -1,20 +1,24 @@
-use crate::{
-    arch::{
-        asm::yield_instruction,
-        registers::{get_cntfrq, get_cntvct},
-    },
-    print,
+use crate::arch::{
+    gtdt::TimerFlags,
+    registers::{get_cntfrq, get_cntvct, set_cntv_ctl, set_cntv_cval},
 };
 
-use super::acpi::AcpiInfo;
+use super::{
+    acpi::AcpiInfo,
+    irq::{configure_interrupt, enable_interrupt},
+};
 
 pub fn initialize(acpi_info: &AcpiInfo) {
     let timer_frequency = get_cntfrq();
-    loop {
-        let start = get_cntvct();
-        while get_cntvct() - start < timer_frequency {
-            yield_instruction(); // ?
-        }
-        print!(".");
-    }
+    set_cntv_ctl(0x1); // Enable the timer, unmask the interrupt
+    set_cntv_cval(get_cntvct() + timer_frequency); // Set the timer compare value to go off in 1 second
+    configure_interrupt(
+        acpi_info.gtdt.timer_interrupt,
+        acpi_info
+            .gtdt
+            .timer_flags
+            .contains(TimerFlags::EDGE_TRIGGERED),
+        0xf0,
+    );
+    enable_interrupt(acpi_info.gtdt.timer_interrupt);
 }

--- a/kernel/src/aarch64/asm.rs
+++ b/kernel/src/aarch64/asm.rs
@@ -14,3 +14,7 @@ pub fn dsb_ish() {
 pub fn yield_instruction() {
     unsafe { asm!("yield", options(nomem, nostack)) }
 }
+
+pub fn enable_interrupts() {
+    unsafe { asm!("msr daifclr, #15", options(nomem, nostack)) }
+}

--- a/kernel/src/aarch64/asm.rs
+++ b/kernel/src/aarch64/asm.rs
@@ -9,3 +9,8 @@ pub fn isb() {
 pub fn dsb_ish() {
     unsafe { asm!("dsb ish", options(nomem, nostack)) }
 }
+
+#[inline(always)]
+pub fn yield_instruction() {
+    unsafe { asm!("yield", options(nomem, nostack)) }
+}

--- a/kernel/src/aarch64/gicv2.rs
+++ b/kernel/src/aarch64/gicv2.rs
@@ -1,0 +1,205 @@
+use core::ops::Range;
+
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::{
+    arch_api::irq::{GenericInterruptController, InterruptInfo},
+    mmio::MmioMemoryHandle,
+};
+
+pub struct Gicv2 {
+    distributor_registers: MmioMemoryHandle,
+    cpu_interface_registers: MmioMemoryHandle,
+
+    cpu_interface_count: u32,
+    available_interrupt_ranges: Box<[Range<u32>]>,
+}
+
+const DISTRIBUTOR_RANGE_LENGTH: usize = 0x1000;
+const CPU_INTERFACE_RANGE_LENGTH: usize = 0x100;
+
+const DISTRIBUTOR_CONTROL_OFFSET: usize = 0x000;
+const DISTRIBUTOR_IDENTIFICATION_OFFSET: usize = 0x004;
+const DISTRIBUTOR_SET_ENABLE_OFFSET: usize = 0x100;
+const DISTRIBUTOR_CLEAR_ENABLE_OFFSET: usize = 0x180;
+
+const CPU_INTERFACE_CONTROL_OFFSET: usize = 0x00;
+const CPU_INTERFACE_ACKNOWLEDGE_REGISTER: usize = 0x0C;
+const CPU_INTERFACE_END_OF_INTERRUPT_REGISTER: usize = 0x10;
+
+impl Gicv2 {
+    /// # Safety
+    /// There must be no other active drivers, and the provided addresses must point to valid GICs.
+    pub unsafe fn new(distributor_address: usize, cpu_interface_address: usize) -> Self {
+        let distributor_registers =
+            MmioMemoryHandle::new(distributor_address, DISTRIBUTOR_RANGE_LENGTH);
+        let cpu_interface_registers =
+            MmioMemoryHandle::new(cpu_interface_address, CPU_INTERFACE_RANGE_LENGTH);
+
+        // The GIC spec recommends that we disable the GIC distributor before doing any discovery.
+        distributor_registers
+            .at_offset::<u32>(DISTRIBUTOR_CONTROL_OFFSET)
+            .write(0x0);
+
+        // The identification register (or interrupt controller type register, according to the spec) has these useful fields:
+        // - bits 4:0: 32(n+1) gives the number of interrupt lines supported by the GIC.
+        // - bits 7:5: n+1 gives the number of CPU interfaces connected to the distributor.
+        let identification_register = distributor_registers
+            .at_offset::<u32>(DISTRIBUTOR_IDENTIFICATION_OFFSET)
+            .read();
+        let interrupt_line_count = 32 * ((identification_register & 0b11111) + 1);
+        let cpu_interface_count = ((identification_register >> 5) & 0b111) + 1;
+
+        // To discover which interrupt lines are usable, we have to do the following:
+        // - Write 0xFFFFFFFF to the set-enable register.
+        // - Read the set-enable register. Any bits set to 0 are unusable.
+        // - Write 0xFFFFFFFF to the clear-enable register.
+        // - Read the clear-enable register. Any bits set to 1 are unusable.
+        // This is necessary since there may be interrupt lines which can't be enabled, or that can't be disabled. Either way we can't use them.
+        let mut unusable_interrupt_lines = Vec::new();
+
+        for enable_register_index in 0..(interrupt_line_count / 32) {
+            distributor_registers
+                .at_offset::<u32>(
+                    DISTRIBUTOR_SET_ENABLE_OFFSET + (enable_register_index as usize * 4),
+                )
+                .write(0xFFFFFFFF);
+            let set_enable_register_value = distributor_registers
+                .at_offset::<u32>(
+                    DISTRIBUTOR_SET_ENABLE_OFFSET + (enable_register_index as usize * 4),
+                )
+                .read();
+
+            distributor_registers
+                .at_offset::<u32>(
+                    DISTRIBUTOR_CLEAR_ENABLE_OFFSET + (enable_register_index as usize * 4),
+                )
+                .write(0xFFFFFFFF);
+            let clear_enable_register_value = distributor_registers
+                .at_offset::<u32>(
+                    DISTRIBUTOR_CLEAR_ENABLE_OFFSET + (enable_register_index as usize * 4),
+                )
+                .read();
+
+            for bit_index in 0..32 {
+                let interrupt_line_index = enable_register_index * 32 + bit_index;
+                let set_enable_bit = (set_enable_register_value >> bit_index) & 0b1;
+                let clear_enable_bit = (clear_enable_register_value >> bit_index) & 0b1;
+
+                if set_enable_bit == 0 || clear_enable_bit == 1 {
+                    unusable_interrupt_lines.push(interrupt_line_index);
+                }
+            }
+        }
+
+        // Now we just have to compose the ranges of usable interrupts from the list of unusable ones.
+        // I think the easiest way would be to store the the last unusable interrupt + 1, then create a range from there to the next unusable one.
+        // It helps here that the list of unusable interrupts is sorted.
+        let mut available_interrupt_ranges = Vec::new();
+        let mut next_range_start = 0;
+        for unusable_interrupt_line in unusable_interrupt_lines {
+            if unusable_interrupt_line > next_range_start {
+                available_interrupt_ranges.push(next_range_start..unusable_interrupt_line);
+            }
+            next_range_start = unusable_interrupt_line + 1;
+        }
+        if next_range_start < interrupt_line_count {
+            available_interrupt_ranges.push(next_range_start..interrupt_line_count);
+        }
+
+        // Finally, we re-enable the distributor.
+        distributor_registers
+            .at_offset::<u32>(DISTRIBUTOR_CONTROL_OFFSET)
+            .write(0x1);
+
+        crate::println!(
+            "Available interrupt lines: {:?}",
+            available_interrupt_ranges
+        );
+
+        Self {
+            distributor_registers,
+            cpu_interface_registers,
+
+            cpu_interface_count,
+            available_interrupt_ranges: available_interrupt_ranges.into_boxed_slice(),
+        }
+    }
+}
+
+impl GenericInterruptController for Gicv2 {
+    fn acknowledge_interrupt(&mut self) -> Option<InterruptInfo> {
+        // SAFETY: we were created with an address, which was required to be valid.
+        let acknowledge_register_value = unsafe {
+            self.cpu_interface_registers
+                .at_offset::<u32>(CPU_INTERFACE_ACKNOWLEDGE_REGISTER)
+                .read()
+        };
+        let interrupt_number = acknowledge_register_value & 0x3FF;
+        if interrupt_number == 1023 {
+            None
+        } else {
+            Some(InterruptInfo {
+                acknowledge_register_value,
+                interrupt_number: acknowledge_register_value & 0x3FF,
+            })
+        }
+    }
+
+    fn end_of_interrupt(&mut self, interrupt_info: InterruptInfo) {
+        // SAFETY: we were created with an address, which was required to be valid.
+        unsafe {
+            self.cpu_interface_registers
+                .at_offset::<u32>(CPU_INTERFACE_END_OF_INTERRUPT_REGISTER)
+                .write(interrupt_info.acknowledge_register_value);
+        }
+    }
+
+    fn enable_interrupt(&mut self, interrupt_number: u32) {
+        assert!(
+            self.interrupt_is_usable(interrupt_number),
+            "attempted to enable an interrupt that is not usable"
+        );
+        // SAFETY: we were created with an address, which was required to be valid.
+        unsafe {
+            self.distributor_registers
+                .at_offset::<u32>(
+                    DISTRIBUTOR_SET_ENABLE_OFFSET + ((interrupt_number / 32) as usize * 4),
+                )
+                .write(1 << (interrupt_number % 32));
+        }
+    }
+
+    fn disable_interrupt(&mut self, interrupt_number: u32) {
+        assert!(
+            self.interrupt_is_usable(interrupt_number),
+            "attempted to disable an interrupt that is not usable"
+        );
+        // SAFETY: we were created with an address, which was required to be valid.
+        unsafe {
+            self.distributor_registers
+                .at_offset::<u32>(
+                    DISTRIBUTOR_CLEAR_ENABLE_OFFSET + ((interrupt_number / 32) as usize * 4),
+                )
+                .write(1 << (interrupt_number % 32));
+        }
+    }
+
+    fn interrupt_is_usable(&self, interrupt_number: u32) -> bool {
+        for available_interrupt_range in self.available_interrupt_ranges.iter() {
+            if available_interrupt_range.contains(&interrupt_number) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn enable_interrupts_for_this_cpu(&mut self) {
+        // SAFETY: we were created with an address, which was required to be valid.
+        unsafe {
+            self.cpu_interface_registers
+                .at_offset::<u32>(CPU_INTERFACE_CONTROL_OFFSET)
+                .write(0x1);
+        }
+    }
+}

--- a/kernel/src/aarch64/mod.rs
+++ b/kernel/src/aarch64/mod.rs
@@ -1,6 +1,7 @@
 pub mod arch_api;
 mod asm;
 mod exceptions;
+mod gicv2;
 mod registers;
 
 #[path = "acpi/gtdt.rs"]

--- a/kernel/src/aarch64/registers.rs
+++ b/kernel/src/aarch64/registers.rs
@@ -7,3 +7,19 @@ pub fn get_esr() -> u64 {
     }
     esr
 }
+
+pub fn get_cntfrq() -> u64 {
+    let mut cntfrq: u64;
+    unsafe {
+        asm!("mrs {}, cntfrq_el0", out(reg) cntfrq, options(nomem, nostack));
+    }
+    cntfrq
+}
+
+pub fn get_cntvct() -> u64 {
+    let mut cntvct: u64;
+    unsafe {
+        asm!("mrs {}, cntvct_el0", out(reg) cntvct, options(nomem, nostack));
+    }
+    cntvct
+}

--- a/kernel/src/aarch64/registers.rs
+++ b/kernel/src/aarch64/registers.rs
@@ -23,3 +23,15 @@ pub fn get_cntvct() -> u64 {
     }
     cntvct
 }
+
+pub fn set_cntv_ctl(cntv_ctl: u64) {
+    unsafe {
+        asm!("msr cntv_ctl_el0, {}", in(reg) cntv_ctl, options(nomem, nostack));
+    }
+}
+
+pub fn set_cntv_cval(cntv_cval: u64) {
+    unsafe {
+        asm!("msr cntv_cval_el0, {}", in(reg) cntv_cval, options(nomem, nostack));
+    }
+}

--- a/kernel/src/acpi/madt.rs
+++ b/kernel/src/acpi/madt.rs
@@ -186,8 +186,8 @@ memory_struct! {
 
 #[derive(Debug)]
 pub struct IoApicInfo {
-    address: u32,
-    global_system_interrupt_base: u32,
+    pub address: u32,
+    pub global_system_interrupt_base: u32,
 }
 
 bitflags! {
@@ -202,36 +202,36 @@ bitflags! {
 
 #[derive(Debug)]
 pub struct InterruptSourceOverrideInfo {
-    bus_source: u8,
-    irq_source: u8,
-    global_system_interrupt: u32,
-    flags: GeneralAPICInterruptFlags,
+    pub bus_source: u8,
+    pub irq_source: u8,
+    pub global_system_interrupt: u32,
+    pub flags: GeneralAPICInterruptFlags,
 }
 
 #[derive(Debug)]
 pub struct LocalApicNmiInfo {
-    flags: GeneralAPICInterruptFlags,
-    local_apic_lint: u8,
+    pub flags: GeneralAPICInterruptFlags,
+    pub local_apic_lint: u8,
 }
 
 #[derive(Debug)]
 pub struct GenericInterruptControllerCpuInterfaceInfo {
-    cpu_interface_number: u32,
-    base_address: u64,
-    mp_id_register: u64,
-    efficiency_class: u8,
+    pub cpu_interface_number: u32,
+    pub base_address: u64,
+    pub mp_id_register: u64,
+    pub efficiency_class: u8,
 }
 
 #[derive(Debug)]
 pub struct GenericInterruptControllerDistributorInfo {
-    base_address: u64,
-    gic_version: u8,
+    pub base_address: u64,
+    pub gic_version: u8,
 }
 
 #[derive(Debug)]
 pub struct GenericInterruptControllerRedistributorInfo {
-    discovery_range_base_address: u64,
-    discovery_range_length: u32,
+    pub discovery_range_base_address: u64,
+    pub discovery_range_length: u32,
 }
 
 #[derive(Debug, Default)]

--- a/kernel/src/heap.rs
+++ b/kernel/src/heap.rs
@@ -324,6 +324,18 @@ impl PhysicalAddressHandle {
         // See above.
         unsafe { core::slice::from_raw_parts_mut(data_pointer, data_size) }
     }
+
+    pub fn as_ptr(handle: &Self) -> *const u8 {
+        handle.pointer as *const u8
+    }
+
+    pub fn as_mut_ptr(handle: &mut Self) -> *mut u8 {
+        handle.pointer
+    }
+
+    pub fn size(handle: &Self) -> usize {
+        handle.size
+    }
 }
 
 impl Deref for PhysicalAddressHandle {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -31,6 +31,7 @@ mod font_renderer;
 mod heap;
 mod lazy_init;
 mod memory;
+mod mmio;
 mod paging;
 mod physical_memory_manager;
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -59,6 +59,7 @@ extern "C" fn kmain() -> ! {
     console::println!("Initialized the display (obviously)");
     let required_acpi_tables = acpi::find_required_acpi_tables().unwrap();
     let acpi_info = arch_api::acpi::handle_acpi_info(required_acpi_tables);
+    arch_api::irq::initialize(&acpi_info);
     arch_api::timer::initialize(&acpi_info);
     loop {}
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -57,7 +57,8 @@ extern "C" fn kmain() -> ! {
     heap::sanity_check();
     console::println!("Initialized the display (obviously)");
     let required_acpi_tables = acpi::find_required_acpi_tables().unwrap();
-    arch_api::acpi::handle_acpi_info(required_acpi_tables);
+    let acpi_info = arch_api::acpi::handle_acpi_info(required_acpi_tables);
+    arch_api::timer::initialize(&acpi_info);
     loop {}
 }
 

--- a/kernel/src/mmio.rs
+++ b/kernel/src/mmio.rs
@@ -1,0 +1,154 @@
+use core::{
+    mem::size_of,
+    ops::{Deref, DerefMut},
+};
+
+use crate::{
+    arch_api::{asm::memory_barrier, paging::MemoryType},
+    heap::{map_physical_memory, PhysicalAddressHandle},
+};
+
+#[derive(Copy, Clone)]
+pub struct MmioPointer<T> {
+    ptr: *mut T,
+}
+
+impl<T> MmioPointer<T> {
+    pub fn new(ptr: *mut T) -> Self {
+        Self { ptr }
+    }
+
+    /// # Safety
+    /// Since this function is essentially a wrapper around a raw pointer, it is inherently unsafe.
+    /// Additionally, MMIO accesses may have side effects, so this function is unsafe for that reason as well.
+    pub unsafe fn read(&self) -> T {
+        let result = unsafe { self.ptr.read_volatile() };
+        memory_barrier();
+        result
+    }
+
+    /// # Safety
+    /// Since this function is essentially a wrapper around a raw pointer, it is inherently unsafe.
+    /// Additionally, MMIO accesses may have side effects, so this function is unsafe for that reason as well.
+    pub unsafe fn write(&mut self, value: T) {
+        unsafe { self.ptr.write_volatile(value) };
+        memory_barrier();
+    }
+}
+
+pub struct MmioRange {
+    start: *mut u8,
+    size: usize,
+}
+
+impl MmioRange {
+    pub fn new(start: *mut u8, size: usize) -> Self {
+        Self { start, size }
+    }
+
+    /// # Safety
+    /// The same rules apply as for performing arithmetic on a raw pointer.
+    pub unsafe fn at_offset<T>(&self, offset: usize) -> MmioPointer<T> {
+        assert!(offset + size_of::<T>() <= self.size);
+        MmioPointer::new(unsafe { self.start.add(offset) as *mut T })
+    }
+
+    pub fn resize(&mut self, new_size: usize) {
+        self.size = new_size;
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+pub struct MmioMemoryHandle {
+    physical_memory_handle: PhysicalAddressHandle,
+    mmio_range: MmioRange,
+}
+
+impl MmioMemoryHandle {
+    /// # Safety
+    /// see `heap::map_physical_memory`.
+    pub unsafe fn new(physical_address: usize, size: usize) -> Self {
+        let mut handle = map_physical_memory(physical_address, size, MemoryType::Device);
+        let mmio_range = MmioRange::new(
+            PhysicalAddressHandle::as_mut_ptr(&mut handle),
+            PhysicalAddressHandle::size(&handle),
+        );
+        Self {
+            physical_memory_handle: handle,
+            mmio_range,
+        }
+    }
+}
+
+impl Deref for MmioMemoryHandle {
+    type Target = MmioRange;
+
+    fn deref(&self) -> &Self::Target {
+        &self.mmio_range
+    }
+}
+
+impl DerefMut for MmioMemoryHandle {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mmio_range
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mmio_pointer_test() {
+        let mut memory = [1u8, 2u8, 3u8, 4u8];
+        let mut mmio_pointer = MmioPointer::<u32>::new(memory.as_mut_ptr() as *mut u32);
+        // SAFETY: It is safe to dereference this pointer, since we are allowed to construct a u32 from arbitrary bytes (assuming the pointer is aligned, which local variables always are).
+        #[cfg(target_endian = "little")]
+        assert_eq!(unsafe { mmio_pointer.read() }, 0x04030201);
+        #[cfg(target_endian = "big")]
+        assert_eq!(unsafe { mmio_pointer.read() }, 0x01020304);
+
+        unsafe { mmio_pointer.write(0xdeadbeef) };
+        #[cfg(target_endian = "little")]
+        assert_eq!(memory, [0xef, 0xbe, 0xad, 0xde]);
+        #[cfg(target_endian = "big")]
+        assert_eq!(memory, [0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn mmio_range_test() {
+        let mut memory = [1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8];
+
+        let mmio_range = MmioRange::new(memory.as_mut_ptr(), memory.len());
+
+        // SAFETY: The offset is within the bounds of the memory range.
+        let mut mmio_pointer = unsafe { mmio_range.at_offset::<u32>(0) };
+
+        #[cfg(target_endian = "little")]
+        assert_eq!(unsafe { mmio_pointer.read() }, 0x04030201);
+        #[cfg(target_endian = "big")]
+        assert_eq!(unsafe { mmio_pointer.read() }, 0x01020304);
+
+        unsafe { mmio_pointer.write(0xdeadbeef) };
+        #[cfg(target_endian = "little")]
+        assert_eq!(memory[..4], [0xef, 0xbe, 0xad, 0xde]);
+        #[cfg(target_endian = "big")]
+        assert_eq!(memory[..4], [0xde, 0xad, 0xbe, 0xef]);
+
+        let mut mmio_pointer = unsafe { mmio_range.at_offset::<u32>(4) };
+
+        #[cfg(target_endian = "little")]
+        assert_eq!(unsafe { mmio_pointer.read() }, 0x08070605);
+        #[cfg(target_endian = "big")]
+        assert_eq!(unsafe { mmio_pointer.read() }, 0x05060708);
+
+        unsafe { mmio_pointer.write(0x0badc0de) };
+        #[cfg(target_endian = "little")]
+        assert_eq!(memory[4..], [0xde, 0xc0, 0xad, 0x0b]);
+        #[cfg(target_endian = "big")]
+        assert_eq!(memory[4..], [0x0b, 0xad, 0xc0, 0xde]);
+    }
+}

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use crate::{
     acpi::{madt::MadtInfo, AcpiTableHandle},
-    arch::hpet::HpetInfo,
+    arch::acpi::hpet::HpetInfo,
 };
 
 static mut ROOT_TABLE_ADDRESS: usize = 0;

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -27,7 +27,12 @@ pub fn get_root_table_address() -> Option<usize> {
     }
 }
 
-pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
+pub struct AcpiInfo {
+    madt: MadtInfo,
+    hpet: HpetInfo,
+}
+
+pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) -> AcpiInfo {
     let mut madt = None;
     let mut hpet = None;
     for table in acpi_tables {
@@ -44,4 +49,9 @@ pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) {
 
     crate::println!("MADT: {:?}", madt);
     crate::println!("HPET: {:?}", hpet);
+
+    AcpiInfo {
+        madt: madt.expect("MADT not found"),
+        hpet: hpet.expect("HPET not found"),
+    }
 }

--- a/kernel/src/x86_64/arch_api/acpi.rs
+++ b/kernel/src/x86_64/arch_api/acpi.rs
@@ -28,8 +28,8 @@ pub fn get_root_table_address() -> Option<usize> {
 }
 
 pub struct AcpiInfo {
-    madt: MadtInfo,
-    hpet: HpetInfo,
+    pub madt: MadtInfo,
+    pub hpet: HpetInfo,
 }
 
 pub fn handle_acpi_info(acpi_tables: Vec<AcpiTableHandle>) -> AcpiInfo {

--- a/kernel/src/x86_64/arch_api/asm.rs
+++ b/kernel/src/x86_64/arch_api/asm.rs
@@ -1,0 +1,7 @@
+use core::arch::asm;
+
+pub fn memory_barrier() {
+    unsafe {
+        asm!("mfence");
+    }
+}

--- a/kernel/src/x86_64/arch_api/irq.rs
+++ b/kernel/src/x86_64/arch_api/irq.rs
@@ -1,0 +1,37 @@
+use crate::arch::{
+    asm::{enable_interrupts, io_wait, write_port8},
+    local_apic,
+};
+
+use super::acpi::AcpiInfo;
+
+pub fn initialize(acpi_info: &AcpiInfo) {
+    // SAFETY: The MADT is required to contain the correct address for the local APIC, and this is the first place it is ever used.
+    unsafe { local_apic::initialize(acpi_info.madt.local_interrupt_controller_address as usize) };
+
+    if acpi_info.madt.flags & 0b1 != 0 {
+        // Legacy PIC present
+        unsafe {
+            // We must disable the legacy PIC so that we don't get interrupts through it in addition to the IO APICs.
+            // Unfortunately, there is no official way to do this.
+            // The generally accepted method is to map it to some reserved range of interrupts, and then mask all interrupts on the primary PIC (including the cascade line to the secondary PIC).
+            write_port8(0x20, 0x11); // Initialize primary PIC
+            io_wait();
+            write_port8(0x21, 0xf8); // Primary PIC starts at interrupt 0xf8, so that the spurious interrupt is 0xff
+            io_wait();
+            write_port8(0x20, 0x01); // Enable primary PIC
+            io_wait();
+            write_port8(0x21, 0x04); // Enable cascade line to secondary PIC
+            io_wait();
+            write_port8(0x21, 0x01); // Put it in 8086 mode (whatever that does)
+
+            // Mask all interrupts on the primary PIC (including the cascade line to the secondary PIC)
+            write_port8(0x21, 0xff);
+        }
+    }
+
+    // TODO: Initialize IO APICs.
+
+    // SAFETY: This is called from main, which doesn't expect interrupts to be disabled.
+    unsafe { enable_interrupts() };
+}

--- a/kernel/src/x86_64/arch_api/mod.rs
+++ b/kernel/src/x86_64/arch_api/mod.rs
@@ -1,5 +1,6 @@
 pub mod acpi;
 pub mod asm;
 pub mod init;
+pub mod irq;
 pub mod paging;
 pub mod timer;

--- a/kernel/src/x86_64/arch_api/mod.rs
+++ b/kernel/src/x86_64/arch_api/mod.rs
@@ -1,4 +1,5 @@
 pub mod acpi;
+pub mod asm;
 pub mod init;
 pub mod paging;
 pub mod timer;

--- a/kernel/src/x86_64/arch_api/mod.rs
+++ b/kernel/src/x86_64/arch_api/mod.rs
@@ -1,3 +1,4 @@
 pub mod acpi;
 pub mod init;
 pub mod paging;
+pub mod timer;

--- a/kernel/src/x86_64/arch_api/timer.rs
+++ b/kernel/src/x86_64/arch_api/timer.rs
@@ -1,16 +1,38 @@
-use crate::{arch::hpet::Hpet, mmio::MmioMemoryHandle, print};
+use crate::{
+    arch::{hpet::Hpet, local_apic},
+    mmio::MmioMemoryHandle,
+    print, println,
+};
 
 use super::acpi::AcpiInfo;
 
 pub fn initialize(acpi_info: &AcpiInfo) {
+    // The prefered timer is the APIC timer, which is specific to each CPU and has a very nice frequency.
+    // The only drawback is that the frequency is specific to the CPU, so we have to synchronize it somehow with another timer.
+    // We use the HPET for this purpose, since it is easy to discover through ACPI, has a good frequency and a very simple interface.
+
+    // What we do specifically is:
+    // 1. Set the APIC timer to count down from 0xffffffff (the highest possible value).
+    // 2. (using the HPET) wait for a specific period of time (we'll go with 100ms).
+    // 3. Read the APIC timer count and calculate the frequency based on the difference from 0xffffffff.
+
     // SAFETY: The ACPI tables are required to give us a good HPET.
     // Additionally, this function is only called once, and then before anything else has had a chance to use the HPET.
     let hpet = unsafe { Hpet::new(acpi_info.hpet.address as usize) };
+
+    unsafe { local_apic::initialize_timer() };
+    unsafe { local_apic::set_timer(0xffffffff) };
+
     unsafe { hpet.reset() };
 
-    loop {
-        let start = unsafe { hpet.counter_value() };
-        while unsafe { hpet.counter_value() } < start + hpet.frequency() {}
-        print!(".");
-    }
+    let end = unsafe { hpet.counter_value() + hpet.frequency() / 10 };
+
+    while unsafe { hpet.counter_value() } < end {}
+
+    let frequency = 10 * (0xffffffff - unsafe { local_apic::read_timer() });
+    local_apic::set_timer_frequency(frequency);
+
+    println!("APIC timer frequency: {}Hz", frequency);
+
+    unsafe { local_apic::set_timer(frequency) };
 }

--- a/kernel/src/x86_64/arch_api/timer.rs
+++ b/kernel/src/x86_64/arch_api/timer.rs
@@ -1,0 +1,5 @@
+use super::acpi::AcpiInfo;
+
+pub fn initialize(acpi_info: &AcpiInfo) {
+    todo!();
+}

--- a/kernel/src/x86_64/arch_api/timer.rs
+++ b/kernel/src/x86_64/arch_api/timer.rs
@@ -1,5 +1,16 @@
+use crate::{arch::hpet::Hpet, mmio::MmioMemoryHandle, print};
+
 use super::acpi::AcpiInfo;
 
 pub fn initialize(acpi_info: &AcpiInfo) {
-    todo!();
+    // SAFETY: The ACPI tables are required to give us a good HPET.
+    // Additionally, this function is only called once, and then before anything else has had a chance to use the HPET.
+    let hpet = unsafe { Hpet::new(acpi_info.hpet.address as usize) };
+    unsafe { hpet.reset() };
+
+    loop {
+        let start = unsafe { hpet.counter_value() };
+        while unsafe { hpet.counter_value() } < start + hpet.frequency() {}
+        print!(".");
+    }
 }

--- a/kernel/src/x86_64/arch_api/timer.rs
+++ b/kernel/src/x86_64/arch_api/timer.rs
@@ -1,7 +1,6 @@
 use crate::{
     arch::{hpet::Hpet, local_apic},
-    mmio::MmioMemoryHandle,
-    print, println,
+    println,
 };
 
 use super::acpi::AcpiInfo;

--- a/kernel/src/x86_64/asm.rs
+++ b/kernel/src/x86_64/asm.rs
@@ -1,0 +1,20 @@
+use core::arch::asm;
+
+/// # Safety
+/// This function could cause undefined behavior if the port does something strange.
+/// For example, a port-mapped DMA controller could overwrite parts of the kernel.
+pub unsafe fn write_port8(port: u16, value: u8) {
+    asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack));
+}
+
+pub fn io_wait() {
+    unsafe {
+        asm!("out dx, al", in("dx") 0x80, in("al") 0u8, options(nomem, nostack));
+    }
+}
+
+/// # Safety
+/// This could break code in the surrounding scope which relies on interrupts being disabled.
+pub unsafe fn enable_interrupts() {
+    asm!("sti", options(nomem, nostack));
+}

--- a/kernel/src/x86_64/hpet.rs
+++ b/kernel/src/x86_64/hpet.rs
@@ -1,0 +1,82 @@
+use crate::mmio::MmioMemoryHandle;
+
+pub struct Hpet {
+    mmio_handle: MmioMemoryHandle,
+
+    frequency: u64,
+}
+
+const HPET_MMIO_SIZE: usize = 1024;
+
+const HPET_CAPABILITIES_OFFSET: usize = 0x00;
+const HPET_GENERAL_CONFIGURATION_OFFSET: usize = 0x10;
+const HPET_GENERAL_INTERRUPT_STATUS_OFFSET: usize = 0x20;
+const HPET_MAIN_COUNTER_VALUE_OFFSET: usize = 0xF0;
+
+impl Hpet {
+    /// # Safety
+    /// The physical address must both point to a HPET, and also not be in use by another instance of the HPET driver or anything else.
+    pub unsafe fn new(physical_address: usize) -> Self {
+        let mmio_handle = MmioMemoryHandle::new(physical_address, HPET_MMIO_SIZE);
+
+        let capabilities = mmio_handle
+            .at_offset::<u64>(HPET_CAPABILITIES_OFFSET)
+            .read();
+        let counter_clock_period = (capabilities >> 32) as u32; // In femtoseconds
+        let frequency = 1_000_000_000_000_000 / counter_clock_period as u64;
+
+        // Here we disable the counter, as well as the legacy mode.
+        let general_configuration = mmio_handle
+            .at_offset::<u64>(HPET_GENERAL_CONFIGURATION_OFFSET)
+            .read();
+        mmio_handle
+            .at_offset::<u64>(HPET_GENERAL_CONFIGURATION_OFFSET)
+            .write(general_configuration & !(1 | 1 << 1));
+
+        Self {
+            mmio_handle,
+            frequency,
+        }
+    }
+
+    pub fn frequency(&self) -> u64 {
+        self.frequency
+    }
+
+    pub unsafe fn counter_value(&self) -> u64 {
+        self.mmio_handle
+            .at_offset::<u64>(HPET_MAIN_COUNTER_VALUE_OFFSET)
+            .read()
+    }
+
+    pub unsafe fn enable(&self) {
+        let mut general_configuration = self
+            .mmio_handle
+            .at_offset::<u64>(HPET_GENERAL_CONFIGURATION_OFFSET)
+            .read();
+        general_configuration |= 1;
+        self.mmio_handle
+            .at_offset::<u64>(HPET_GENERAL_CONFIGURATION_OFFSET)
+            .write(general_configuration);
+    }
+
+    pub unsafe fn disable(&self) {
+        let mut general_configuration = self
+            .mmio_handle
+            .at_offset::<u64>(HPET_GENERAL_CONFIGURATION_OFFSET)
+            .read();
+        general_configuration &= !1;
+        self.mmio_handle
+            .at_offset::<u64>(HPET_GENERAL_CONFIGURATION_OFFSET)
+            .write(general_configuration);
+    }
+
+    /// Restart the counter at 0.
+    pub unsafe fn reset(&self) {
+        self.disable();
+        self.mmio_handle
+            .at_offset::<u64>(HPET_MAIN_COUNTER_VALUE_OFFSET)
+            .write(0);
+        self.enable();
+    }
+}

--- a/kernel/src/x86_64/local_apic.rs
+++ b/kernel/src/x86_64/local_apic.rs
@@ -1,0 +1,138 @@
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use bitflags::bitflags;
+
+use crate::mmio::MmioMemoryHandle;
+
+use super::interrupts::{SPURIOUS_INTERRUPT_VECTOR, TIMER_INTERRUPT};
+
+static mut APIC_HANDLE: Option<MmioMemoryHandle> = None;
+
+const LOCAL_APIC_MEMORY_RANGE_SIZE: usize = 0x1000;
+
+const LOCAL_APIC_ID_OFFSET: usize = 0x20;
+const LOCAL_APIC_VERSION_OFFSET: usize = 0x30;
+const LOCAL_APIC_TASK_PRIORITY_OFFSET: usize = 0x80;
+const LOCAL_APIC_ARBITRATION_PRIORITY_OFFSET: usize = 0x90;
+const LOCAL_APIC_PROCESSOR_PRIORITY_OFFSET: usize = 0xA0;
+const LOCAL_APIC_EOI_OFFSET: usize = 0xB0;
+const LOCAL_APIC_REMOTE_READ_OFFSET: usize = 0xC0;
+const LOCAL_APIC_LOGICAL_DESTINATION_OFFSET: usize = 0xD0;
+const LOCAL_APIC_DESTINATION_FORMAT_OFFSET: usize = 0xE0;
+const LOCAL_APIC_SPURIOUS_INTERRUPT_VECTOR_OFFSET: usize = 0xF0;
+
+const LOCAL_APIC_IN_SERVICE_BASE_OFFSET: usize = 0x100;
+const LOCAL_APIC_TRIGGER_MODE_BASE_OFFSET: usize = 0x180;
+const LOCAL_APIC_INTERRUPT_REQUEST_BASE_OFFSET: usize = 0x200;
+
+const LOCAL_APIC_ERROR_STATUS_OFFSET: usize = 0x280;
+const LOCAL_APIC_INTERRUPT_COMMAND_OFFSET: usize = 0x300;
+const LOCAL_APIC_LVT_TIMER_OFFSET: usize = 0x320;
+const LOCAL_APIC_LVT_THERMAL_SENSOR_OFFSET: usize = 0x330;
+const LOCAL_APIC_LVT_PERFORMANCE_MONITORING_COUNTERS_OFFSET: usize = 0x340;
+const LOCAL_APIC_LVT_LINT0_OFFSET: usize = 0x350;
+const LOCAL_APIC_LVT_LINT1_OFFSET: usize = 0x360;
+const LOCAL_APIC_LVT_ERROR_OFFSET: usize = 0x370;
+const LOCAL_APIC_TIMER_INITIAL_COUNT_OFFSET: usize = 0x380;
+const LOCAL_APIC_TIMER_CURRENT_COUNT_OFFSET: usize = 0x390;
+const LOCAL_APIC_TIMER_DIVIDE_CONFIGURATION_OFFSET: usize = 0x3E0;
+
+/// # Safety
+/// The physical address must both point to a APIC, and also not be in use by another instance of the APIC driver or be mapped anywhere else.
+/// Additionally, there will be massive confusion if the legacy PIC is not disabled by now, so callers must ensure that it is disabled.
+pub unsafe fn initialize(address: usize) {
+    APIC_HANDLE = Some(MmioMemoryHandle::new(address, LOCAL_APIC_MEMORY_RANGE_SIZE));
+
+    let Some(apic_handle) = APIC_HANDLE.as_mut() else {
+        panic!("APIC handle not initialized");
+    };
+
+    // To enable the APIC, we have to set the spurious interrupt vector with bit 8 set to 1.
+    apic_handle
+        .at_offset::<u32>(LOCAL_APIC_SPURIOUS_INTERRUPT_VECTOR_OFFSET)
+        .write(SPURIOUS_INTERRUPT_VECTOR as u32 | 0x100);
+}
+
+/// # Safety
+/// The APIC must be initialized properly (see above).
+pub unsafe fn end_of_interrupt() {
+    let Some(apic_handle) = APIC_HANDLE.as_mut() else {
+        panic!("APIC handle not initialized");
+    };
+
+    apic_handle.at_offset::<u32>(LOCAL_APIC_EOI_OFFSET).write(0);
+}
+
+bitflags! {
+    pub struct LvtFlags: u32 {
+        const TIMER_MODE_PERIODIC = 1 << 17;
+        const MASKED = 1 << 16;
+        const TRIGGER_MODE_LEVEL = 1 << 15;
+        const INTERRUPT_ACTIVE = 1 << 14;
+        const INTERRUPT_PENDING = 1 << 12;
+        // const MESSAGE_TYPE_FIXED = 0b000 << 8; // The default
+        const MESSAGE_TYPE_SMI = 0b010 << 8;
+        const MESSAGE_TYPE_NMI = 0b100 << 8;
+        const MESSAGE_TYPE_EXTINT = 0b111 << 8;
+    }
+}
+
+/// # Safety
+/// The APIC must be initialized properly (see above).
+pub unsafe fn initialize_timer() {
+    let Some(apic_handle) = APIC_HANDLE.as_mut() else {
+        panic!("APIC handle not initialized");
+    };
+
+    // We set the timer to be one-shot, with an initial count of 0 and a divisor of 64.
+    apic_handle
+        .at_offset::<u32>(LOCAL_APIC_LVT_TIMER_OFFSET)
+        .write(TIMER_INTERRUPT as u32);
+
+    apic_handle
+        .at_offset::<u32>(LOCAL_APIC_TIMER_INITIAL_COUNT_OFFSET)
+        .write(0);
+
+    apic_handle
+        .at_offset::<u32>(LOCAL_APIC_TIMER_DIVIDE_CONFIGURATION_OFFSET)
+        .write(0b1001);
+}
+
+static TIMER_FREQUENCY: AtomicU64 = AtomicU64::new(0);
+
+pub fn set_timer_frequency(frequency: u64) {
+    TIMER_FREQUENCY.store(frequency, Ordering::SeqCst);
+}
+
+pub fn get_timer_frequency() -> u64 {
+    TIMER_FREQUENCY.load(Ordering::SeqCst)
+}
+
+/// Read the raw count from the timer.
+/// Callers will generally want to convert this to some normal unit of time, which would generally involve multiplying by some value (e.g. 1000 for milliseconds) and dividing by the frequency.
+///
+/// # Safety
+/// The APIC must be initialized properly (see above).
+pub unsafe fn read_timer() -> u64 {
+    let Some(apic_handle) = APIC_HANDLE.as_mut() else {
+        panic!("APIC handle not initialized");
+    };
+
+    apic_handle
+        .at_offset::<u32>(LOCAL_APIC_TIMER_CURRENT_COUNT_OFFSET)
+        .read() as u64
+}
+
+/// Set the timer to fire after the given number of ticks.
+///
+/// # Safety
+/// The APIC must be initialized properly (see above).
+pub unsafe fn set_timer(ticks: u64) {
+    let Some(apic_handle) = APIC_HANDLE.as_mut() else {
+        panic!("APIC handle not initialized");
+    };
+
+    apic_handle
+        .at_offset::<u32>(LOCAL_APIC_TIMER_INITIAL_COUNT_OFFSET)
+        .write(ticks as u32);
+}

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -1,6 +1,8 @@
 pub mod arch_api;
+mod hpet;
 mod interrupts;
 mod multiboot;
 
-#[path = "acpi/hpet.rs"]
-mod hpet;
+mod acpi {
+    pub(in crate::arch) mod hpet;
+}

--- a/kernel/src/x86_64/mod.rs
+++ b/kernel/src/x86_64/mod.rs
@@ -1,6 +1,8 @@
 pub mod arch_api;
+mod asm;
 mod hpet;
 mod interrupts;
+mod local_apic;
 mod multiboot;
 
 mod acpi {


### PR DESCRIPTION
This adds code to initialize the timers (Local APIC timer for x86 and generic timer for Aarch64). Since these timers are best used with interrupts, this PR also implements drivers for the Local APIC (x86) and Generic Interrupt Controller (GIC, only version 2 so far) for Aarch64.